### PR TITLE
fix: make the label say the email, rather, than name (#62)

### DIFF
--- a/tui/inbox.go
+++ b/tui/inbox.go
@@ -448,9 +448,6 @@ func (m *Inbox) SetEmails(emails []fetcher.Email, accounts []config.Account) {
 	tabs := []AccountTab{{ID: "", Label: "ALL", Email: ""}}
 	for _, acc := range accounts {
 		label := acc.Email
-		if acc.Name != "" {
-			label = acc.Name
-		}
 		tabs = append(tabs, AccountTab{ID: acc.ID, Label: label, Email: acc.Email})
 	}
 	m.tabs = tabs


### PR DESCRIPTION
This pull request makes a minor update to the way account tabs are labeled in the inbox UI. Now, the tab label always uses the account's email address, even if a display name is present.

* Always use the account email as the label for each tab in the inbox, removing previous logic that preferred the account's display name if available (`tui/inbox.go`).

Before:

<img width="358" height="54" alt="Screenshot 2025-12-28 at 12 27 20" src="https://github.com/user-attachments/assets/d68de3b1-3a9a-4a86-b9ff-52e578184988" />


After: 

<img width="393" height="47" alt="Screenshot 2025-12-28 at 12 26 40" src="https://github.com/user-attachments/assets/f28b5f79-3011-48e9-b79f-2ba8d9f824a9" />
