### PR TITLE
Change placeholder from 'Host' to 'Username'

### DIFF
--- a/tui/login.go
+++ b/tui/login.go
@@ -53,7 +53,7 @@ func NewLogin() *Login {
 			t.Placeholder = "Display Name"
 			t.Prompt = "👤 > "
 		case inputEmail:
-			t.Placeholder = "Host"
+			t.Placeholder = "Username"
 			t.Prompt = "🏠 > "
 		case inputFetchEmail:
 			t.Placeholder = "Email Address"


### PR DESCRIPTION
Host is ambiguous, you actually mean Username/Email address. I spent about half an hour debugging this, I use my own address I've built and this field only worked for me when I entered in my email address / username. 

Thank you for such a great tool!