### PR TITLE
fix: use fetch email in the account selector

### DIFF
--- a/tui/composer.go
+++ b/tui/composer.go
@@ -447,7 +447,7 @@ func (m *Composer) View() string {
 		for i, acc := range m.accounts {
 			display := acc.Email
 			if acc.Name != "" {
-				display = fmt.Sprintf("%s (%s)", acc.Name, acc.Email)
+				display = fmt.Sprintf("%s (%s)", acc.Name, acc.FetchEmail)
 			}
 			if i == m.selectedAccountIdx {
 				accountList.WriteString(selectedItemStyle.Render(fmt.Sprintf("> %s", display)))


### PR DESCRIPTION
Replaces `Email` for `FetchEmail` in the account selector.

## Reason:

The `Email` is the hostname for the SMTP (and IMAP) servers, and the `FetchEmail` is actually the one that the email is sent from.