### PR TITLE
fix: refresh/load-more cursor reset (#170)

### DIFF
--- a/tui/messages.go
+++ b/tui/messages.go
@@ -281,4 +281,5 @@ type EmailsRefreshedMsg struct {
 // RequestRefreshMsg signals a request to refresh emails from the server.
 type RequestRefreshMsg struct {
 	Mailbox MailboxKind
+	Counts  map[string]int
 }


### PR DESCRIPTION
Fixes #170

## Changes:

* When reloaded, or more emails are loaded, the cursor stays in the same spot

* Urgent fix: when more emails were loaded, they were not cached. With changes in #149, this caused an unpleasant experience. Emails cached are set to a limit of 100 (for all). 

* Refresh checks to make sure no emails are duplicated, nor deleted from cache by accident. 