### PR TITLE
feat: flatpakref added to the website

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,7 +5,9 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
-
+  # ALSO run when a new GitHub Release is published
+  release:
+    types: [published]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -31,13 +33,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Install Flatpak Builder
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Build Flatpak Repo
+        run: |
+          flatpak-builder --repo=public/repo --force-clean build-dir com.floatpane.matcha.yaml
+          flatpak build-update-repo --generate-static-deltas public/repo
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
           # Upload entire repository
-          path: 'public'
+          path: "public"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/com.floatpane.matcha.yaml
+++ b/com.floatpane.matcha.yaml
@@ -1,0 +1,22 @@
+id: com.floatpane.matcha
+runtime: org.freedesktop.Sdk
+runtime-version: "23.08"
+sdk: org.freedesktop.Sdk
+command: matcha
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --device=dri
+  - --filesystem=home
+
+modules:
+  - name: matcha
+    buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
+    build-commands:
+      - go build -o /app/bin/matcha .
+    sources:
+      - type: dir
+        path: .

--- a/public/matcha.flatpakref
+++ b/public/matcha.flatpakref
@@ -1,0 +1,7 @@
+[Flatpak Ref]
+Name=com.floatpane.matcha
+Branch=master
+Title=Matcha
+IsRuntime=False
+Url=https://matcha.floatpane.com/repo/
+SuggestRemoteName=matcha


### PR DESCRIPTION
Closes #176 

Adds a `.flatpakref` file with the basic structure, as well as, `com.floatpane.matcha.yaml` with build instructions. This is integrated in the `static.yml` workflow to publish the new ref