### PR TITLE
fix: sort email batches by date instead of UID

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -307,14 +307,11 @@ func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset u
 			})
 		}
 
-		// Sort batch Newest -> Oldest (since IMAP usually returns Oldest->Newest or arbitrary)
-		// Assuming seqset order or standard behavior, we want to ensure we append Newest emails first
-		// so that the final list is correct.
-		// Actually, let's just sort the batch by UID desc (Newest first)
-		// Simple bubble sort for small batch
+		// Sort batch by Date descending (newest first)
+		// UID ordering is not reliable for all IMAP servers (e.g. Proton Bridge)
 		for i := 0; i < len(batchEmails); i++ {
 			for j := i + 1; j < len(batchEmails); j++ {
-				if batchEmails[j].UID > batchEmails[i].UID {
+				if batchEmails[j].Date.After(batchEmails[i].Date) {
 					batchEmails[i], batchEmails[j] = batchEmails[j], batchEmails[i]
 				}
 			}


### PR DESCRIPTION
## Summary

- Fix email sort order for custom IMAP providers (e.g. Proton Bridge) that don't guarantee UID chronological ordering
- Replace UID-based batch sorting with Date-based sorting in `FetchMailboxEmails()`, consistent with the Date-based sorting already used in `flattenAndSort()` and `EmailsRefreshedMsg`

Fixes #230

## Test plan

- [x] Verified fix with Proton Mail Bridge — emails now display newest-first
- [x] `go build ./...` passes
- [x] `go test ./...` passes (existing sort-order assertion in `TestFetchEmails` validates this behavior)
- [x] Gmail provider unaffected — no change in behavior
- [x] iCloud unaffected — uses standard IMAP with reliable UID ordering, Date sort produces equivalent results