### PR TITLE
fix: mark emails as read when opened

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -794,7 +794,27 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 		}
 	}
 
+	MarkEmailAsRead(account, mailbox, uid)
+
 	return body, attachments, nil
+}
+
+func MarkEmailAsRead(account *config.Account, mailbox string, uid uint32) error {
+	c, err := connect(account)
+	if err != nil {
+		return err
+	}
+	defer c.Logout()
+
+	if _, err := c.Select(mailbox, false); err != nil {
+		return err
+	}
+
+	seqSet := new(imap.SeqSet)
+	seqSet.AddNum(uid)
+	item := imap.FormatFlagsOp(imap.AddFlags, true)
+	flags := []interface{}{imap.SeenFlag}
+	return c.UidStore(seqSet, item, flags, nil)
 }
 
 func FetchAttachmentFromMailbox(account *config.Account, mailbox string, uid uint32, partID string, encoding string) ([]byte, error) {


### PR DESCRIPTION
## Summary

- Add `MarkEmailAsRead()` function that sets the IMAP `\Seen` flag on a message
- Call it from `FetchEmailBodyFromMailbox()` after successfully fetching the email body
- Uses `BODY.PEEK[]` (unchanged) for fetching to keep fetch and flag-setting separate

Fixes #232

## Test plan

- [x] Verified with Gmail — emails marked as read in web interface after opening in Matcha
- [x] Verified with Proton Mail (via Proton Bridge) — same behavior
- [x] `go build ./...` passes
- [x] `go test ./...` passes