### PR TITLE
fix: strip commas from email before contacts

### DIFF
--- a/config/cache.go
+++ b/config/cache.go
@@ -153,7 +153,7 @@ func AddContact(name, email string) error {
 		return nil
 	}
 
-	email = strings.ToLower(strings.TrimSpace(email))
+	email = strings.ToLower(strings.Trim(strings.TrimSpace(email), ","))
 	name = strings.TrimSpace(name)
 
 	cache, err := LoadContactsCache()

--- a/main.go
+++ b/main.go
@@ -752,10 +752,16 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		go func() {
 			// Save the recipient as a contact
 			if msg.To != "" {
-				// Parse "Name <email>" format
-				name, email := parseEmailAddress(msg.To)
-				if err := config.AddContact(name, email); err != nil {
-					log.Printf("Error saving contact: %v", err)
+				recipients := strings.Split(msg.To, ",")
+				for _, r := range recipients {
+					r = strings.TrimSpace(r)
+					if r == "" {
+						continue
+					}
+					name, email := parseEmailAddress(r)
+					if err := config.AddContact(name, email); err != nil {
+						log.Printf("Error saving contact: %v", err)
+					}
 				}
 			}
 			// Delete the draft since email is being sent


### PR DESCRIPTION

## What Changed

Split `msg.To` by comma before saving so each recipient is saved individually. This also handles the trailing `, ` the composer appends after suggestion selection. I skipped the empty parts from the split

I added comma trimming in `AddContact` just in case for persistence part

After all, I sent two emails to [friend@floatpane.com](mailto:friend@floatpane.com), and checked out the `contacts.json`:

```json
{
  "contacts": [
    {
      "name": "",
      "email": "friend@floatpane.com",
      "last_used": "2026-03-09T10:08:44.582981-04:00",
      "use_count": 2
    }
  ],
  "updated_at": "2026-03-09T10:08:44.582995-04:00"
}      
```
there is no duplicate. If there is any issue, please let me know 🙌.
Closes #251