### PR TITLE
feat: To field in emails

### DIFF
--- a/tui/email_view.go
+++ b/tui/email_view.go
@@ -205,7 +205,7 @@ func (m *EmailView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case tea.WindowSizeMsg:
-		header := fmt.Sprintf("From: %s\nSubject: %s", m.email.From, m.email.Subject)
+		header := fmt.Sprintf("To: %s\nFrom: %s\nSubject: %s ", strings.Join(m.email.To, ", "), m.email.From, m.email.Subject)
 		headerHeight := lipgloss.Height(header) + 2
 		attachmentHeight := 0
 		if len(m.email.Attachments) > 0 {
@@ -252,7 +252,7 @@ func (m *EmailView) View() tea.View {
 		}
 	}
 
-	header := fmt.Sprintf("From: %s | Subject: %s%s", m.email.From, m.email.Subject, smimeStatus)
+	header := fmt.Sprintf("To: %s | From: %s | Subject: %s%s", strings.Join(m.email.To, ", "), m.email.From, m.email.Subject, smimeStatus)
 	styledHeader := emailHeaderStyle.Width(m.viewport.Width()).Render(header)
 
 	var help string


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Adds a `To` field, that includes all recipients, separated by a comma.  

<img width="1037" height="1286" alt="Screenshot 2026-03-10 at 10 06 02" src="https://github.com/user-attachments/assets/779a7de6-28d0-48e6-9b08-f1edeb160787" />

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what feature does it enable? Link related issues if applicable. -->

This makes it easier to view sent messages (uses the same `composer`) also, provides the information about all the recepients of the email.