### PR TITLE
ci: labeller keywords

### DIFF
--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -1,6 +1,6 @@
 "bug": '\b([Bb]ug(s)?|[Ee]rror(s)?|[Ff]ix(es)?)\b'
 
-"enhancement": '\b([Ee]nhancement(s)?|[Ff]eature(s)?|[Ii]dea(s)?|[Ss]uggestion(s)?[Ff]eat(s)?)\b'
+"enhancement": '\b([Ee]nhancement(s)?|[Ff]eature(s)?|[Ii]dea(s)?)\b'
 
 "documentation": '\b([Dd]ocumentation|[Dd]ocs|[Rr]eadme)\b'
 


### PR DESCRIPTION

## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->
Removes "add(s)" and "suggestion(s)" keywords from the labeller config
## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what feature does it enable? Link related issues if applicable. -->

Labels all PRs automatically by mistake