### PR TITLE
fix!: sent emails not showing bug (#279)

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -298,7 +298,11 @@ func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset u
 
 			matched := false
 			if isSentMailbox {
-				if strings.EqualFold(strings.TrimSpace(fromAddr), fetchEmail) {
+				var senderEmail string
+				if len(msg.Envelope.From) > 0 {
+					senderEmail = msg.Envelope.From[0].Address()
+				}
+				if strings.EqualFold(strings.TrimSpace(senderEmail), fetchEmail) {
 					matched = true
 				}
 			} else {


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Fix sent mailbox emails not displaying by using the raw email address for sender matching instead of the formatted address string.

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

In `FetchMailboxEmails`, the sent mailbox filter compared `fromAddr` (from `formatAddress()`) against `fetchEmail`. When the sender has a personal name set, `formatAddress()` returns `"Name <email>"`, while `fetchEmail` is just `"email"` — so `strings.EqualFold` never matched and the folder appeared empty.

This is inconsistent with how recipient matching already works for other folders, where `addr.Address()` (raw email only) is used.

Fixes #279 