### PR TITLE
ci: fix paths in workflow

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -115,7 +115,7 @@ jobs:
           # Move generated screenshots to public assets, clean up intermediate gifs
           mv screenshots/*.png docs/docs/assets/ 2>/dev/null || true
           rm -f screenshots/*.gif 2>/dev/null || true
-          ls -la public/assets/screenshots/
+          ls -la docs/docs/assets/
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
@@ -138,4 +138,4 @@ jobs:
             - `drafts.png` - Draft management view
           branch: "update-screenshots"
           base: "master"
-          add-paths: public/assets/screenshots/
+          add-paths: docs/docs/assets/


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Fixes updated paths in the screenshot workflow. 



## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->
Paths were updated in the workflow, but not fully, causing the workflow to go to `public/assets/screenshots` instead of `docs/docs/assets` to commit