### PR TITLE
chore: make renovate bump go by patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,9 @@
     {
       "matchPackageNames": ["go"],
       "matchManagers": ["gomod", "github-actions"],
-      "groupName": "go"
+      "groupName": "go",
+      "rangeStrategy": "bump",
+      "updateTypes": ["major", "minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Allows renovate to bump the Go version by patches too (default: major, minor)

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

As per #135 we want to use the upstream Go version.