### PR TITLE
fix: restore MarkEmailAsRead — re-apply #233 lost in folders refactor (#322)

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -815,7 +815,27 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 		}
 	}
 
+	MarkEmailAsRead(account, mailbox, uid)
+
 	return body, attachments, nil
+}
+
+func MarkEmailAsRead(account *config.Account, mailbox string, uid uint32) error {
+	c, err := connect(account)
+	if err != nil {
+		return err
+	}
+	defer c.Logout()
+
+	if _, err := c.Select(mailbox, false); err != nil {
+		return err
+	}
+
+	seqSet := new(imap.SeqSet)
+	seqSet.AddNum(uid)
+	item := imap.FormatFlagsOp(imap.AddFlags, true)
+	flags := []interface{}{imap.SeenFlag}
+	return c.UidStore(seqSet, item, flags, nil)
 }
 
 func FetchAttachmentFromMailbox(account *config.Account, mailbox string, uid uint32, partID string, encoding string) ([]byte, error) {


### PR DESCRIPTION
## Summary

Fixes #322

## Root Cause

The fix from PR #233 (commit `fbddb86`) was inadvertently dropped during the folders refactor introduced in commit `d525efb` (#240). The `MarkEmailAsRead()` function and its call site in `FetchEmailBodyFromMailbox()` are both absent from the current `master`.

## Changes

Restores `fetcher/fetcher.go` to include:

1. The call to `MarkEmailAsRead()` at the end of `FetchEmailBodyFromMailbox()` (before `return body, attachments, nil`)
2. The `MarkEmailAsRead()` function itself, which opens a fresh IMAP connection and sets the `\\Seen` flag via `UidStore`

The logic is identical to what was merged in #233 — no behaviour changes.

Note: errors from `MarkEmailAsRead` are intentionally not propagated. The email body was fetched successfully and the UI should still render it even if flagging fails (read-only mailbox, transient network error, etc.).