### PR TITLE
FEAT: Highlight unread email

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -50,6 +50,7 @@ type Email struct {
 	References  []string
 	Attachments []Attachment
 	AccountID   string // ID of the account this email belongs to
+	Seen        bool
 }
 
 // Folder represents an IMAP mailbox/folder.
@@ -261,7 +262,7 @@ func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset u
 
 		messages := make(chan *imap.Message, chunkSize)
 		done := make(chan error, 1)
-		fetchItems := []imap.FetchItem{imap.FetchEnvelope, imap.FetchUid}
+		fetchItems := []imap.FetchItem{imap.FetchEnvelope, imap.FetchUid, imap.FetchFlags}
 
 		go func() {
 			done <- c.Fetch(seqset, fetchItems, messages)
@@ -318,6 +319,14 @@ func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset u
 				continue
 			}
 
+			seen := false
+			for _, f := range msg.Flags {
+				if f == imap.SeenFlag {
+					seen = true
+					break
+				}
+			}
+
 			batchEmails = append(batchEmails, Email{
 				UID:       msg.Uid,
 				From:      fromAddr,
@@ -325,6 +334,7 @@ func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset u
 				Subject:   decodeHeader(msg.Envelope.Subject),
 				Date:      msg.Envelope.Date,
 				AccountID: account.ID,
+				Seen:      seen,
 			})
 		}
 
@@ -1065,7 +1075,7 @@ func FetchArchiveEmails(account *config.Account, limit, offset uint32) ([]Email,
 
 	messages := make(chan *imap.Message, limit)
 	done := make(chan error, 1)
-	fetchItems := []imap.FetchItem{imap.FetchEnvelope, imap.FetchUid}
+	fetchItems := []imap.FetchItem{imap.FetchEnvelope, imap.FetchUid, imap.FetchFlags}
 	go func() {
 		done <- c.Fetch(seqset, fetchItems, messages)
 	}()
@@ -1124,6 +1134,14 @@ func FetchArchiveEmails(account *config.Account, limit, offset uint32) ([]Email,
 			continue
 		}
 
+		seen := false
+		for _, f := range msg.Flags {
+			if f == imap.SeenFlag {
+				seen = true
+				break
+			}
+		}
+
 		emails = append(emails, Email{
 			UID:       msg.Uid,
 			From:      fromAddr,
@@ -1131,6 +1149,7 @@ func FetchArchiveEmails(account *config.Account, limit, offset uint32) ([]Email,
 			Subject:   decodeHeader(msg.Envelope.Subject),
 			Date:      msg.Envelope.Date,
 			AccountID: account.ID,
+			Seen:      seen,
 		})
 	}
 


### PR DESCRIPTION


The `Email` struct lacked a `Seen` field, so callers had no way to distinguish read from unread messages. The root cause was that `FetchMailboxEmails` and `FetchArchiveEmails` only requested `imap.FetchEnvelope` and `imap.FetchUid` from the IMAP server, omitting `imap.FetchFlags` entirely. Adds `Seen bool` to the `Email` struct in `fetcher/fetcher.go` and includes `imap.FetchFlags` in the fetch item list for both functions, then checks each message's flags for `imap.SeenFlag` before constructing the `Email` value. Verified by inspecting the IMAP flag-fetching path in `FetchMailboxEmails` and `FetchArchiveEmails` to confirm the flag is populated correctly.