### PR TITLE
style: add horizontal padding to the dialog windows

### DIFF
--- a/tui/styles.go
+++ b/tui/styles.go
@@ -22,7 +22,7 @@ var (
 	DialogBoxStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("#25A065")).
-			Padding(1, 0).
+			Padding(1, 2).
 			BorderTop(true).
 			BorderLeft(true).
 			BorderRight(true).

--- a/tui/theme.go
+++ b/tui/theme.go
@@ -14,7 +14,7 @@ func RebuildStyles() {
 	DialogBoxStyle = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(t.AccentDark).
-		Padding(1, 0).
+		Padding(1, 2).
 		BorderTop(true).
 		BorderLeft(true).
 		BorderRight(true).


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Adds horizontal padding to `DialogBoxStyle`.



## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

Will improve readability, as well as make the interface more polished.

<img width="2052" height="1286" alt="Screenshot 2026-03-18 at 11 54 33" src="https://github.com/user-attachments/assets/61b51c70-d466-474b-8905-64ba8f43a8a5" />

*Before and after, where before is on the right and after on the left*