### PR TITLE
fix: S/MIME settings typo

### DIFF
--- a/tui/settings.go
+++ b/tui/settings.go
@@ -562,7 +562,7 @@ func (m *Settings) viewSMIMEConfig() string {
 	var b strings.Builder
 
 	account := m.cfg.Accounts[m.editingAccountIdx]
-	b.WriteString(titleStyle.Render(fmt.Sprintf("S/MIME Configuration for %s", account.Email)))
+	b.WriteString(titleStyle.Render(fmt.Sprintf("S/MIME Configuration for %s", account.FetchEmail)))
 	b.WriteString("\n\n")
 
 	if m.focusIndex == 0 {


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Fixes a typo in S/MIME settings with displaying `account.Email` instead of `account.FetchEmail`

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

More accurate information, because you click on FetchEmail and get into "Email" settings