### PR TITLE
fix: update dialog box wording for draft confirmation

### DIFF
--- a/tui/composer.go
+++ b/tui/composer.go
@@ -629,7 +629,7 @@ func (m *Composer) View() tea.View {
 	if m.confirmingExit {
 		dialog := DialogBoxStyle.Render(
 			lipgloss.JoinVertical(lipgloss.Center,
-				"Exit email composer? This draft will be saved",
+				"Are you sure you want to exit? This draft will be saved",
 				HelpStyle.Render("\n(y/n)"),
 			),
 		)


### PR DESCRIPTION
## What?

Changed the wording of the dialog box of the leave composer message in composer.go

## Why?

Fixes #345

The old wording was incorrect about discarding the draft. The new wording is clearer about what actually happens to the composed email draft
