### PR TITLE
fix: draft saving race condition

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,11 +150,11 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Save draft to disk
 		if msg.ComposerState != nil {
 			draft := msg.ComposerState.ToDraft()
-			go func() {
-				if err := config.SaveDraft(draft); err != nil {
-					log.Printf("Error saving draft: %v", err)
-				}
-			}()
+
+			if err := config.SaveDraft(draft); err != nil {
+				log.Printf("Error saving draft: %v", err)
+			}
+
 		}
 		m.current = tui.NewChoice()
 		m.current, _ = m.current.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})

--- a/tui/mailing_list.go
+++ b/tui/mailing_list.go
@@ -29,10 +29,10 @@ func NewMailingListEditor() *MailingListEditor {
 	addr.Placeholder = "e.g., alice@example.com, bob@example.com"
 
 	return &MailingListEditor{
-		nameInput:  name,
-		addrInput:  addr,
-		focus:      0,
-		editIndex:  -1,
+		nameInput: name,
+		addrInput: addr,
+		focus:     0,
+		editIndex: -1,
 	}
 }
 

--- a/view/html.go
+++ b/view/html.go
@@ -56,7 +56,6 @@ func getTerminalCellSize() int {
 	return defaultCellHeight
 }
 
-
 // hyperlinkSupported checks if the terminal supports OSC 8 hyperlinks.
 func hyperlinkSupported() bool {
 	term := strings.ToLower(os.Getenv("TERM"))


### PR DESCRIPTION
## What?

Removed the go routine spawned when creating a draft to force draft creation to run synchronously. 
Ran make lint.

## Why?

When the draft list was empty, saving the first draft did not immediately show Drafts in the main menu. The draft save was happening asynchronously, so menu construction could run before the draft existed, creating a race with NewChoice. Saving the draft synchronously before rebuilding the menu removes the race and makes Drafts appear immediately.