### PR TITLE
ci: update flake workflow to create PR

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update:
@@ -20,14 +21,18 @@ jobs:
       - name: Update flake.lock
         run: nix flake update
 
-      - name: Commit and push changes
+      - name: Create Pull Request
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           git diff --quiet flake.lock && exit 0
+          BRANCH="chore/update-flake-lock"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "chore: update flake.lock (#228)"
-          git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git
-          git push origin HEAD:${GITHUB_REF}
+          git checkout -b "$BRANCH"
+          git add flake.lock
+          git commit -m "chore: update flake.lock"
+          git push -f origin "$BRANCH"
+          if ! gh pr list --head "$BRANCH" --state open | grep -q .; then
+            gh pr create --title "chore: update flake.lock" --body "Automated flake.lock update." --base master
+          fi


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Updated the workflow to create a pull request, instead of committing directly to the master branch.

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

Protection rule-sets were added to matcha repository, including:

1. Release immunity: assets and tags cannot be edited
2. Master branch protection: master branch cannot be committed to, without a PR   