### PR TITLE
ci: remove goimportpath

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,4 +20,3 @@ parts:
   matcha:
     plugin: go
     source: .
-    go-importpath: github.com/floatpane/matcha


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Removes `goimportpath` from snapcraft config

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

Newer versions of snapcraft do not support `goimportpath`, they detect it automatically