### PR TITLE
ci: prevent release workflows work on nightly

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   update-demo:
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
     name: Generate and Update Demo GIF
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mastodon-notify.yml
+++ b/.github/workflows/mastodon-notify.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   post-to-fosstodon:
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
       - name: Send Post to Fosstodon

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   generate-screenshots:
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
     name: Generate Feature Screenshots
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Added a check for pre-release and if `false` it goes on

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

So that for each nightly build there wont be a Mastodon post, as well as 2 PRs opening 