### PR TITLE
ci: exclude nightly from compare on release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,10 @@
 # For more information, see: https://goreleaser.com/customization/
 version: 2
 
+git:
+  ignore_tags:
+    - nightly*
+
 # The 'before' hook runs commands before the build process starts.
 before:
   hooks:


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Adds ignore nightly tags to the git compare in goreleaser 

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

The [v0.28.0](https://github.com/floatpane/matcha/releases/tag/v0.28.0) release notes were practically empty, because it compared to nightlyv0, which is released on each commit