### PR TITLE
fix!: IMAP IDLE behavior

### DIFF
--- a/fetcher/idle.go
+++ b/fetcher/idle.go
@@ -47,8 +47,8 @@ func (w *IdleWatcher) Watch(account *config.Account, folder string) {
 	// Stop existing watcher for this account if any
 	if existing, ok := w.watchers[account.ID]; ok {
 		close(existing.stop)
-		<-existing.done
 		delete(w.watchers, account.ID)
+		// Let old connection tear down in the background
 	}
 
 	a := &accountIdle{
@@ -62,6 +62,18 @@ func (w *IdleWatcher) Watch(account *config.Account, folder string) {
 	go a.run()
 }
 
+// Stop stops the IDLE watcher for a specific account.
+func (w *IdleWatcher) Stop(accountID string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if a, ok := w.watchers[accountID]; ok {
+		close(a.stop)
+		delete(w.watchers, accountID)
+		// Let old connection tear down in the background
+	}
+}
+
 // StopAll stops all IDLE watchers.
 func (w *IdleWatcher) StopAll() {
 	w.mu.Lock()
@@ -69,8 +81,23 @@ func (w *IdleWatcher) StopAll() {
 
 	for id, a := range w.watchers {
 		close(a.stop)
-		<-a.done
 		delete(w.watchers, id)
+	}
+}
+
+// StopAllAndWait stops all IDLE watchers and waits for them to finish.
+func (w *IdleWatcher) StopAllAndWait() {
+	w.mu.Lock()
+	var pending []chan struct{}
+	for id, a := range w.watchers {
+		close(a.stop)
+		pending = append(pending, a.done)
+		delete(w.watchers, id)
+	}
+	w.mu.Unlock()
+
+	for _, done := range pending {
+		<-done
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -416,6 +417,12 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Update IDLE watchers to monitor the new folder
 		for i := range m.config.Accounts {
+			// Only start IDLE for accounts that actually have this folder
+			folders := config.GetCachedFolders(m.config.Accounts[i].ID)
+			if !slices.Contains(folders, msg.FolderName) {
+				m.idleWatcher.Stop(m.config.Accounts[i].ID)
+				continue
+			}
 			m.idleWatcher.Watch(&m.config.Accounts[i], msg.FolderName)
 		}
 		if m.plugins != nil {


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Skip IMAP IDLE for accounts that don't have the selected folder, and make IDLE stop/restart non-blocking so it doesn't freeze the UI.

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

When switching to a folder that only some accounts have, IDLE was started for every account — causing repeated "no such mailbox" errors for accounts missing that folder. Additionally, all IDLE stop/restart operations blocked on the UI goroutine waiting for IMAP connections to gracefully close, which takes seconds per connection and froze the app on folder switches and quit.