### PR TITLE
fix: change envelope address to FetchEmail (actual email address)

### DIFF
--- a/sender/sender.go
+++ b/sender/sender.go
@@ -694,7 +694,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 	}
 
 	// Send Envelope
-	if err = c.Mail(account.Email); err != nil {
+	if err = c.Mail(account.FetchEmail); err != nil {
 		return err
 	}
 	for _, r := range allRecipients {


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Changed envelope address to `FetchEmail`. which is the actual email address.

This would fix the issue, when the `Email` (AKA `Username`) is not an email.

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

Fixes #448 