### PR TITLE
fix(imap): close debug log file handle to prevent fd leak

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -16,8 +16,8 @@ import (
 	"net/textproto"
 	"os"
 	"slices"
-	"sync"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -16,6 +16,7 @@ import (
 	"net/textproto"
 	"os"
 	"slices"
+	"sync"
 	"strings"
 	"time"
 
@@ -29,6 +30,28 @@ import (
 	"golang.org/x/text/encoding/ianaindex"
 	"golang.org/x/text/transform"
 )
+
+// debugIMAPFile holds a single shared file handle for IMAP debug logging,
+// opened once via debugIMAPOnce to avoid leaking a descriptor per connection.
+var (
+	debugIMAPFile *os.File
+	debugIMAPOnce sync.Once
+)
+
+func getDebugIMAPWriter() io.Writer {
+	debugIMAPOnce.Do(func() {
+		if path := os.Getenv("DEBUG_IMAP"); path != "" {
+			f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+			if err == nil {
+				debugIMAPFile = f
+			}
+		}
+	})
+	if debugIMAPFile != nil {
+		return debugIMAPFile
+	}
+	return nil
+}
 
 // Attachment holds data for an email attachment.
 type Attachment struct {
@@ -243,10 +266,8 @@ func connectWithOptions(account *config.Account, extraOpts *imapclient.Options) 
 		options.UnilateralDataHandler = extraOpts.UnilateralDataHandler
 		options.DebugWriter = extraOpts.DebugWriter
 	}
-	if path := os.Getenv("DEBUG_IMAP"); path != "" {
-		if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600); err == nil {
-			options.DebugWriter = f
-		}
+	if w := getDebugIMAPWriter(); w != nil {
+		options.DebugWriter = w
 	}
 
 	var c *imapclient.Client


### PR DESCRIPTION
Fixes #504

`connectWithOptions()` was opening a new debug log file handle every time an IMAP connection was created when `DEBUG_IMAP` is set, but never closing it. over time this leaks a file descriptor per connection (fetches, IDLE reconnects, etc).

moved the `os.OpenFile` call into a `sync.Once` so theres one shared handle for the entire process lifetime. the helper `getDebugIMAPWriter()` returns the cached `io.Writer` or nil if the env var isnt set.

pretty straightforward fix, lmk if theres anything I missed