### PR TITLE
fix(notify): check for notification binary before exec

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -1,19 +1,31 @@
 package notify
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"runtime"
 )
 
+// ErrNotAvailable is returned when the required notification tool is not
+// installed on the system (notify-send on Linux, osascript on macOS).
+var ErrNotAvailable = errors.New("desktop notification tool not found")
+
 // Send delivers a desktop notification with the given title and body.
 // On macOS it uses osascript; on Linux it uses notify-send.
+// Returns ErrNotAvailable if the notification binary cannot be found.
 func Send(title, body string) error {
 	switch runtime.GOOS {
 	case "darwin":
+		if _, err := exec.LookPath("osascript"); err != nil {
+			return fmt.Errorf("%w: osascript: %v", ErrNotAvailable, err)
+		}
 		script := fmt.Sprintf(`display notification %q with title %q sound name "default"`, body, title)
 		return exec.Command("osascript", "-e", script).Run()
 	case "linux":
+		if _, err := exec.LookPath("notify-send"); err != nil {
+			return fmt.Errorf("%w: notify-send: %v", ErrNotAvailable, err)
+		}
 		return exec.Command("notify-send", title, body).Run()
 	default:
 		return nil

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -1,0 +1,21 @@
+package notify
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSendReturnsErrNotAvailableOnMissingBinary(t *testing.T) {
+	// On CI or headless systems, notify-send / osascript are typically absent.
+	// If the binary happens to be installed, Send succeeds and we skip the
+	// sentinel-error check — the important thing is that it doesn't panic.
+	err := Send("test", "hello")
+	if err == nil {
+		t.Skip("notification tool is available on this system; skipping")
+	}
+	if !errors.Is(err, ErrNotAvailable) {
+		// A non-ErrNotAvailable error means the binary was found but
+		// execution failed for another reason — that's acceptable too.
+		t.Logf("Send returned a non-ErrNotAvailable error: %v", err)
+	}
+}


### PR DESCRIPTION
While looking into desktop notification support on headless Linux systems, I noticed that `notify.Send` calls `notify-send` / `osascript` directly without first checking whether the binary exists on `$PATH`. On minimal installs (Alpine, headless Debian, WSL without a desktop session, etc.) this silently swallows an `exec.ErrNotFound` and the user gets no feedback.

This change uses `exec.LookPath` to verify the binary exists before attempting to run it, and introduces a sentinel error `ErrNotAvailable` so callers can distinguish "tool not installed" from "tool crashed at runtime". This keeps the existing behavior on systems where the tools are present, while giving a clear signal on systems where they aren't.

I also added a basic test that exercises the `Send` path — it skips cleanly when a notification tool happens to be installed.
