### PR TITLE
fix: limit remote image response body to prevent memory exhaustion

### DIFF
--- a/view/html.go
+++ b/view/html.go
@@ -299,7 +299,10 @@ func fetchRemoteBase64(url string) string {
 		debugImageProtocol("remote fetch non-200 url=%s status=%d", url, resp.StatusCode)
 		return ""
 	}
-	data, err := io.ReadAll(resp.Body)
+	// Limit response body to 10 MB to prevent memory exhaustion from
+	// malicious or very large images.
+	const maxImageSize = 10 << 20 // 10 MB
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImageSize))
 	if err != nil {
 		debugImageProtocol("remote fetch read error url=%s err=%v", url, err)
 		return ""


### PR DESCRIPTION
Fixes #523

## Problem

`io.ReadAll(resp.Body)` reads the entire response without any size limit when fetching remote images for HTML email rendering. A malicious email could reference a URL serving a very large file or slowly streaming infinite data, causing excessive memory usage.

## Fix

Wrap `resp.Body` with `io.LimitReader` capped at 10 MB. This prevents unbounded memory allocation while still allowing reasonable image sizes.