### PR TITLE
fix(notify): surface and log errors when notify-send/osascript missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -627,7 +627,11 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					accountName = acc.Email
 				}
 			}
-			go notify.Send("Matcha", fmt.Sprintf("New mail in %s (%s)", msg.FolderName, accountName))
+			go func(folderName, accName string) {
+				if err := notify.Send("Matcha", fmt.Sprintf("New mail in %s (%s)", folderName, accName)); err != nil {
+					log.Printf("Desktop notification failed: %v", err)
+				}
+			}(msg.FolderName, accountName)
 		}
 
 		// IDLE detected new mail — refetch the folder if we're viewing it

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -8,12 +8,23 @@ import (
 
 // Send delivers a desktop notification with the given title and body.
 // On macOS it uses osascript; on Linux it uses notify-send.
+//
+// If the platform-specific helper binary is not on PATH (common on minimal
+// Linux installs or Wayland-only setups that do not ship notify-send), Send
+// returns an explicit error instead of silently swallowing the failure so
+// callers can log or surface it in the UI. See #522.
 func Send(title, body string) error {
 	switch runtime.GOOS {
 	case "darwin":
+		if _, err := exec.LookPath("osascript"); err != nil {
+			return fmt.Errorf("desktop notifications require osascript, which was not found on PATH: %w", err)
+		}
 		script := fmt.Sprintf(`display notification %q with title %q sound name "default"`, body, title)
 		return exec.Command("osascript", "-e", script).Run()
 	case "linux":
+		if _, err := exec.LookPath("notify-send"); err != nil {
+			return fmt.Errorf("desktop notifications require notify-send (libnotify / notify-osd), which was not found on PATH: %w", err)
+		}
 		return exec.Command("notify-send", title, body).Run()
 	default:
 		return nil

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -1,0 +1,62 @@
+package notify
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestSend_ReturnsErrorWhenBinaryMissing verifies that Send() reports a
+// useful error instead of silently swallowing it when the platform-specific
+// notification helper is not on PATH. See #522.
+func TestSend_ReturnsErrorWhenBinaryMissing(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skipf("unsupported GOOS for this test: %s", runtime.GOOS)
+	}
+
+	// Replace PATH with an empty directory so neither osascript nor
+	// notify-send can be resolved. This matches the minimal-Linux /
+	// headless scenario in the issue.
+	emptyDir := filepath.Join(t.TempDir(), "empty")
+	if err := os.Mkdir(emptyDir, 0o755); err != nil {
+		t.Fatalf("mkdir empty dir: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", oldPath) })
+	if err := os.Setenv("PATH", emptyDir); err != nil {
+		t.Fatalf("setenv PATH: %v", err)
+	}
+
+	err := Send("title", "body")
+	if err == nil {
+		t.Fatalf("expected error when notification binary missing, got nil")
+	}
+
+	// The wrapped error message should name the expected tool so a caller
+	// logging this can tell the user what to install.
+	msg := err.Error()
+	var wanted string
+	switch runtime.GOOS {
+	case "darwin":
+		wanted = "osascript"
+	case "linux":
+		wanted = "notify-send"
+	}
+	if !strings.Contains(msg, wanted) {
+		t.Fatalf("error %q does not mention expected binary %q", msg, wanted)
+	}
+}
+
+// TestSend_ReturnsNilOnUnsupportedGOOS keeps the pre-fix contract intact:
+// Windows (and anything else) should fall through without erroring.
+func TestSend_ReturnsNilOnUnsupportedGOOS(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		t.Skipf("this test only runs on unsupported platforms, current: %s", runtime.GOOS)
+	}
+	if err := Send("title", "body"); err != nil {
+		t.Fatalf("expected nil on %s, got %v", runtime.GOOS, err)
+	}
+}


### PR DESCRIPTION
## Summary

Stop silently losing desktop notifications when `notify-send` / `osascript` aren't installed. `notify.Send` now probes for the helper binary with `exec.LookPath` and returns a descriptive error, and the single production call site (`main.go:630`) wraps the goroutine so the error is logged rather than dropped. Addresses #522.

## Why

`notify.Send` shells out to platform-specific tools to raise desktop notifications. Two failure modes were both invisible to the user:

1. **Binary missing.** Minimal Linux installs, Wayland-only setups, and headless images regularly ship without `libnotify` (`notify-send`), and macOS containers / automated test hosts often omit `osascript`. `exec.Command(...).Run()` just returned that error silently.
2. **Caller throws the error away.** The only production caller, `main.go:630`, used `go notify.Send(...)` which discards the return value entirely. Even without the missing-binary failure, the user had no chance to see anything the Send path reported.

Net effect: on affected setups new-mail notifications never fired and nothing logged -- matches the report in #522.

## Changes

`notify/notify.go`:

- Each OS branch now calls `exec.LookPath(...)` first. If the required tool is not on PATH, return `fmt.Errorf("desktop notifications require <tool>, which was not found on PATH: %w", err)` naming the missing dependency so the caller can log a useful message.
- The happy path is unchanged once the binary exists.

`main.go:630`:

- Wrap the goroutine so `notify.Send`'s error is piped through the existing `log.Printf` path (used elsewhere in the file for backend/oauth failures). Captures folder and account by value so the message is consistent even if `msg`/`acc` mutate between trigger and send.

## Testing

- Added `notify/notify_test.go`:
  - `TestSend_ReturnsErrorWhenBinaryMissing`: replaces `PATH` with an empty directory, runs `Send`, asserts a non-nil error whose message mentions the platform's expected binary (`osascript` on darwin, `notify-send` on linux). Simulates the minimal-install scenario.
  - `TestSend_ReturnsNilOnUnsupportedGOOS`: preserves the original `nil` return on Windows/other platforms.
- `go test ./notify/...` passes.
- Full `go test ./...` shows a pre-existing failure in `view/TestImageProtocolSupported/No_supported_terminals` that is **not** caused by this patch (reproduced on `master` via `git stash`); otherwise clean.
- `go build ./...` passes (CGO libc warnings in `clib/md4c.c` are pre-existing macOS-only `OFF_MAX` macro redefinition warnings, unrelated).



This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
