### PR TITLE
sender: return errors from quoted-printable encoding in SendEmail

### DIFF
--- a/sender/sender.go
+++ b/sender/sender.go
@@ -213,11 +213,17 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 			return nil, errors.New("plaintext-only messages cannot contain attachments or inline images")
 		}
 
-		// Build quoted-printable encoded body
+		// Build quoted-printable encoded body. Close() flushes the final
+		// soft-line-break state, so an ignored error here would silently ship
+		// a truncated body. See #614.
 		var encBody bytes.Buffer
 		qp := quotedprintable.NewWriter(&encBody)
-		fmt.Fprint(qp, plainBody)
-		qp.Close()
+		if _, err := fmt.Fprint(qp, plainBody); err != nil {
+			return nil, fmt.Errorf("encoding plain body: %w", err)
+		}
+		if err := qp.Close(); err != nil {
+			return nil, fmt.Errorf("encoding plain body: %w", err)
+		}
 		encodedBody := encBody.Bytes()
 
 		// Build the canonical MIME part (headers + body) used for signing/encryption
@@ -356,8 +362,12 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 			return nil, err
 		}
 		qpText := quotedprintable.NewWriter(textPart)
-		fmt.Fprint(qpText, plainBody)
-		qpText.Close()
+		if _, err := fmt.Fprint(qpText, plainBody); err != nil {
+			return nil, fmt.Errorf("encoding text part: %w", err)
+		}
+		if err := qpText.Close(); err != nil {
+			return nil, fmt.Errorf("encoding text part: %w", err)
+		}
 
 		// HTML part
 		htmlHeader := textproto.MIMEHeader{
@@ -369,8 +379,12 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 			return nil, err
 		}
 		qpHTML := quotedprintable.NewWriter(htmlPart)
-		fmt.Fprint(qpHTML, htmlBody)
-		qpHTML.Close()
+		if _, err := fmt.Fprint(qpHTML, htmlBody); err != nil {
+			return nil, fmt.Errorf("encoding html part: %w", err)
+		}
+		if err := qpHTML.Close(); err != nil {
+			return nil, fmt.Errorf("encoding html part: %w", err)
+		}
 
 		altWriter.Close() // Finish the alternative part
 


### PR DESCRIPTION
### Problem

`sender/sender.go` builds quoted-printable bodies in three places and
drops the `Close` error on the floor every time:

```go
qp := quotedprintable.NewWriter(&encBody)
fmt.Fprint(qp, plainBody)
qp.Close()  // error ignored
```

`quotedprintable.Writer.Close` flushes the final soft-line-break state
and any buffered partial output, so a silent failure there hands the
rest of the MIME assembly a truncated or ill-formed body, and the
corrupted message is sent. #614 flagged the plaintext-only path at
line 220; the same pattern exists twice more in the multipart path:

- line 220: plaintext-only body
- line 360: `text/plain` part inside `multipart/alternative`
- line 373: `text/html` part inside `multipart/alternative`

### Fix

`SendEmail` already returns `([]byte, error)`. Propagate the error from
`Fprint` and `Close` at all three sites with a wrapped message so the
caller can tell which part failed. No behaviour change on the happy path.

```diff
- fmt.Fprint(qp, plainBody)
- qp.Close()
+ if _, err := fmt.Fprint(qp, plainBody); err != nil {
+     return nil, fmt.Errorf("encoding plain body: %w", err)
+ }
+ if err := qp.Close(); err != nil {
+     return nil, fmt.Errorf("encoding plain body: %w", err)
+ }
```

Fixes #614
