### PR TITLE
plugin/http_test: use ok-form type assertions so tests fail instead of panic

### DIFF
--- a/plugin/http_test.go
+++ b/plugin/http_test.go
@@ -48,14 +48,23 @@ func TestHTTPGet(t *testing.T) {
 		t.Fatalf("expected table, got %T", res)
 	}
 
-	if status := tbl.RawGetString("status"); status.(lua.LNumber) != 200 {
+	statusVal := tbl.RawGetString("status")
+	status, ok := statusVal.(lua.LNumber)
+	if !ok {
+		t.Fatalf("expected status to be number, got %T", statusVal)
+	}
+	if status != 200 {
 		t.Errorf("expected status 200, got %v", status)
 	}
 	if body := tbl.RawGetString("body"); body.String() != "ok" {
 		t.Errorf("expected body 'ok', got %q", body.String())
 	}
 
-	headers := tbl.RawGetString("headers").(*lua.LTable)
+	headersVal := tbl.RawGetString("headers")
+	headers, ok := headersVal.(*lua.LTable)
+	if !ok {
+		t.Fatalf("expected headers to be table, got %T", headersVal)
+	}
 	if v := headers.RawGetString("x-test"); v.String() != "hello" {
 		t.Errorf("expected header x-test='hello', got %q", v.String())
 	}
@@ -96,7 +105,10 @@ func TestHTTPPostWithBodyAndHeaders(t *testing.T) {
 	}
 
 	res := m.state.GetGlobal("res")
-	tbl := res.(*lua.LTable)
+	tbl, ok := res.(*lua.LTable)
+	if !ok {
+		t.Fatalf("expected table, got %T", res)
+	}
 	if body := tbl.RawGetString("body"); body.String() != `{"key":"value"}` {
 		t.Errorf("expected echoed body, got %q", body.String())
 	}


### PR DESCRIPTION
### Problem

`plugin/http_test.go` has three unchecked type assertions on Lua values:

- line 51: `status.(lua.LNumber)`
- line 58: `tbl.RawGetString("headers").(*lua.LTable)` — called out in #615
- line 99: `res.(*lua.LTable)`

If a future change to the http plugin (or a failing test setup) ever
produces the wrong Lua type at any of these slots, the test crashes
with an interface-conversion panic:

```
panic: interface conversion: lua.LValue is lua.LNil, not *lua.LTable
```

instead of reporting a useful failure. Line 46 already uses the safe
`ok`-form assertion, so this just brings the rest of the file up to
the same pattern.

### Fix

Use the `ok` form and call `t.Fatalf` with the actual type when the
expected type doesn't hold:

```go
headersVal := tbl.RawGetString("headers")
headers, ok := headersVal.(*lua.LTable)
if !ok {
    t.Fatalf("expected headers to be table, got %T", headersVal)
}
```

Same treatment for the other two sites. Happy path unchanged.

Fixes #615
