### PR TITLE
main: sanitize attachment filenames before writing to disk

### DIFF
--- a/main.go
+++ b/main.go
@@ -2390,6 +2390,36 @@ func moveEmailToFolderCmd(account *config.Account, uid uint32, accountID string,
 	}
 }
 
+// sanitizeAttachmentFilename returns a filename safe to join with a trusted
+// directory. It strips any directory component the sender put in the name
+// (so "../../etc/passwd" collapses to "passwd"), replaces both path separators
+// even on the wrong platform (Windows clients can see "/", unix clients "\"),
+// trims leading dots that would produce hidden files, and falls back to a
+// generic name when the sender supplies an empty or nothing-but-separators
+// string. Used by the attachment download path; see #642.
+func sanitizeAttachmentFilename(name string) string {
+	// Drop any directory component (e.g. "foo/bar.txt" -> "bar.txt",
+	// "../../etc/passwd" -> "passwd"). filepath.Base handles the active
+	// OS separator; we also strip the alternate separator so a Windows
+	// name on a unix host (or vice versa) cannot sneak a segment through.
+	name = filepath.Base(name)
+	name = strings.ReplaceAll(name, "/", "_")
+	name = strings.ReplaceAll(name, "\\", "_")
+
+	// Strip NUL bytes just in case (some filesystems accept them, most do not).
+	name = strings.ReplaceAll(name, "\x00", "")
+
+	// A leading dot would create a hidden file on unix, which is
+	// surprising for a user-triggered download. Collapse any leading
+	// dots and spaces.
+	name = strings.TrimLeft(name, ". ")
+
+	if name == "" {
+		name = "attachment"
+	}
+	return name
+}
+
 func downloadAttachmentCmd(account *config.Account, uid uint32, msg tui.DownloadAttachmentMsg) tea.Cmd {
 	return func() tea.Msg {
 		// Download and decode the attachment using encoding provided in msg.Encoding.
@@ -2421,8 +2451,12 @@ func downloadAttachmentCmd(account *config.Account, uid uint32, msg tui.Download
 		}
 
 		// Save the attachment using an exclusive create so we never overwrite an existing file.
-		// If the filename already exists, append \" (n)\" before the extension.
-		origName := msg.Filename
+		// If the filename already exists, append " (n)" before the extension.
+		// The sender-supplied msg.Filename is untrusted - a hostile email can
+		// set it to "../../etc/passwd" or contain path separators that escape
+		// downloadsPath. Normalise with filepath.Base and strip stray path
+		// characters before using it (#642).
+		origName := sanitizeAttachmentFilename(msg.Filename)
 		ext := filepath.Ext(origName)
 		base := strings.TrimSuffix(origName, ext)
 		candidate := origName


### PR DESCRIPTION
### Problem

`downloadAttachmentCmd` takes `msg.Filename` (the MIME
Content-Disposition filename set by the sender) and passes it directly
into `filepath.Join(downloadsPath, candidate)` inside an
`O_CREATE|O_EXCL` open:

```go
origName := msg.Filename
ext := filepath.Ext(origName)
base := strings.TrimSuffix(origName, ext)
candidate := origName
...
filePath = filepath.Join(downloadsPath, candidate)
f, err := os.OpenFile(filePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
```

The sender controls that header, so a hostile email can send

```
Content-Disposition: attachment; filename="../../etc/passwd"
Content-Disposition: attachment; filename="..\\evil.txt"
```

and the exclusive-create happens outside `~/Downloads`. `O_EXCL` means
the attack needs a path that does not already exist, but placing a file
anywhere the user can write (e.g. `~/.ssh/authorized_keys2`,
`~/.config/<something>`, a shell init dotfile) is still reachable (#642).

### Fix

Add `sanitizeAttachmentFilename` and wire it into `origName`:

- `filepath.Base` to drop any directory prefix (`../../etc/passwd` → `passwd`)
- replace both `/` and `\` so Windows-authored headers can't sneak a
  segment through on unix, and vice versa
- strip NUL bytes
- trim leading `.` / space so `.bashrc` or `...` doesn't silently
  create a hidden file
- fall back to `"attachment"` when the cleaned name is empty

Happy-path filenames (e.g. `report.pdf`) round-trip unchanged. The
`(n)` suffix logic and `downloadsPath` creation are untouched.

Fixes #642
