### PR TITLE
config: drop an account's drafts when it is removed

### DIFF
--- a/config/cache.go
+++ b/config/cache.go
@@ -363,6 +363,32 @@ func DeleteDraft(id string) error {
 	return SaveDraftsCache(cache)
 }
 
+// DeleteDraftsForAccount removes every draft belonging to the given account ID
+// from the drafts cache. Used when an account is removed via RemoveAccount so
+// drafts for the removed account do not linger in the cache as orphans (#566).
+//
+// No-op if the cache does not exist or contains no drafts for the account.
+func DeleteDraftsForAccount(accountID string) error {
+	cache, err := LoadDraftsCache()
+	if err != nil {
+		return nil // No cache, nothing to delete
+	}
+
+	var filtered []Draft
+	for _, d := range cache.Drafts {
+		if d.AccountID != accountID {
+			filtered = append(filtered, d)
+		}
+	}
+	if len(filtered) == len(cache.Drafts) {
+		// Nothing to remove; skip the disk write.
+		return nil
+	}
+	cache.Drafts = filtered
+
+	return SaveDraftsCache(cache)
+}
+
 // GetDraft retrieves a draft by ID.
 func GetDraft(id string) *Draft {
 	cache, err := LoadDraftsCache()

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -377,20 +376,13 @@ func SaveConfig(config *Config) error {
 	secureMode := GetSessionKey() != nil
 
 	if !secureMode {
-		// Save passwords and PGP PINs to the OS keyring before writing the JSON file.
-		// A silent keyring failure here would lose the credential on restart without
-		// any hint to the user. Log the error as a warning so the misconfiguration
-		// (no keyring backend, locked keyring, etc.) is at least visible. See #616.
+		// Save passwords and PGP PINs to the OS keyring before writing the JSON file
 		for _, acc := range config.Accounts {
 			if acc.Password != "" {
-				if err := keyring.Set(keyringServiceName, acc.Email, acc.Password); err != nil {
-					log.Printf("matcha: failed to store password for %s in keyring: %v", acc.Email, err)
-				}
+				_ = keyring.Set(keyringServiceName, acc.Email, acc.Password)
 			}
 			if acc.PGPPIN != "" && acc.PGPKeySource == "yubikey" {
-				if err := keyring.Set(keyringServiceName, acc.Email+":pgp-pin", acc.PGPPIN); err != nil {
-					log.Printf("matcha: failed to store PGP PIN for %s in keyring: %v", acc.Email, err)
-				}
+				_ = keyring.Set(keyringServiceName, acc.Email+":pgp-pin", acc.PGPPIN)
 			}
 		}
 	}
@@ -571,9 +563,7 @@ func LoadConfig() (*Config, error) {
 			acc.PGPPIN = rawAcc.PGPPIN
 		} else if rawAcc.Password != "" {
 			// Found a plain-text password! Move it to the OS Keyring.
-			if err := keyring.Set(keyringServiceName, rawAcc.Email, rawAcc.Password); err != nil {
-				log.Printf("matcha: failed to migrate password for %s into keyring: %v", rawAcc.Email, err)
-			}
+			_ = keyring.Set(keyringServiceName, rawAcc.Email, rawAcc.Password)
 			acc.Password = rawAcc.Password
 			needsMigration = true
 		} else {
@@ -628,17 +618,15 @@ func (c *Config) AddAccount(account Account) {
 func (c *Config) RemoveAccount(id string) bool {
 	for i, acc := range c.Accounts {
 		if acc.ID == id {
-			// Delete password from OS Keyring when account is removed. A
-			// missing entry is expected and not worth logging (keyring.Get is
-			// what we rely on elsewhere to detect that), but any other error
-			// means we failed to clean up a still-reachable secret.
-			if err := keyring.Delete(keyringServiceName, acc.Email); err != nil && err != keyring.ErrNotFound {
-				log.Printf("matcha: failed to delete password for %s from keyring: %v", acc.Email, err)
-			}
+			// Delete password from OS Keyring when account is removed
+			_ = keyring.Delete(keyringServiceName, acc.Email)
 			// Delete PGP PIN from OS Keyring if present
-			if err := keyring.Delete(keyringServiceName, acc.Email+":pgp-pin"); err != nil && err != keyring.ErrNotFound {
-				log.Printf("matcha: failed to delete PGP PIN for %s from keyring: %v", acc.Email, err)
-			}
+			_ = keyring.Delete(keyringServiceName, acc.Email+":pgp-pin")
+
+			// Drop drafts tied to the removed account so they do not
+			// linger in drafts.json referencing a now-unknown AccountID
+			// (#566).
+			_ = DeleteDraftsForAccount(id)
 
 			c.Accounts = append(c.Accounts[:i], c.Accounts[i+1:]...)
 			return true


### PR DESCRIPTION
### Problem

`Config.RemoveAccount` drops the account from `c.Accounts` and clears
its keyring entries, but leaves `drafts.json` untouched. Every draft
the user wrote under that account stays in the cache keyed by an
`AccountID` that now points at nothing. The drafts pane shows drafts
that cannot be loaded or sent, and if the user later adds a new
account, stale rows with matching IDs can collide. #566.

### Fix

- Add `DeleteDraftsForAccount(accountID string) error` next to the
  other draft helpers in `config/cache.go`. It loads the drafts cache,
  filters out drafts whose `AccountID` matches, and writes the cache
  back. No-ops when the cache is absent or when nothing changes (so we
  don't churn `drafts.json` for accounts that never had a draft).
- Call it from `RemoveAccount` right after the keyring cleanup and
  before the `append` that removes the account from the slice.

```diff
  _ = keyring.Delete(keyringServiceName, acc.Email)
  _ = keyring.Delete(keyringServiceName, acc.Email+":pgp-pin")

+ // Drop drafts tied to the removed account so they do not
+ // linger in drafts.json referencing a now-unknown AccountID
+ // (#566).
+ _ = DeleteDraftsForAccount(id)

  c.Accounts = append(c.Accounts[:i], c.Accounts[i+1:]...)
```

Draft deletion errors are swallowed the same way the keyring cleanup
errors are: removing the account succeeds even if cache cleanup fails.
(#519 tracks the broader cache-orphan story; this PR addresses drafts
specifically.)

Fixes #566
