### PR TITLE
notify: detect missing notifier and log a one-time warning

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -1,21 +1,52 @@
 package notify
 
 import (
+	"errors"
 	"fmt"
+	"log"
 	"os/exec"
 	"runtime"
+	"sync"
 )
 
+// ErrNotifierMissing is returned by Send when the platform's notification
+// command (notify-send on Linux, osascript on macOS) is not installed or
+// not on PATH. Callers that fire-and-forget still get a predictable error
+// instead of whatever exec.ErrNotFound happens to unwrap to.
+var ErrNotifierMissing = errors.New("notify: platform notifier not installed")
+
+// warnOnce guarantees that a single "notifier not installed" warning is
+// logged per process even when Send is called repeatedly from a goroutine
+// whose error is discarded (go notify.Send(...) in main.go).
+var warnOnce sync.Once
+
 // Send delivers a desktop notification with the given title and body.
-// On macOS it uses osascript; on Linux it uses notify-send.
+// On macOS it uses osascript; on Linux it uses notify-send. When the
+// platform notifier is unavailable the function returns ErrNotifierMissing
+// and logs a single warning per process so headless or minimal installs
+// are not silently broken (#522).
 func Send(title, body string) error {
+	var bin string
+	var args []string
+
 	switch runtime.GOOS {
 	case "darwin":
+		bin = "osascript"
 		script := fmt.Sprintf(`display notification %q with title %q sound name "default"`, body, title)
-		return exec.Command("osascript", "-e", script).Run()
+		args = []string{"-e", script}
 	case "linux":
-		return exec.Command("notify-send", title, body).Run()
+		bin = "notify-send"
+		args = []string{title, body}
 	default:
 		return nil
 	}
+
+	if _, err := exec.LookPath(bin); err != nil {
+		warnOnce.Do(func() {
+			log.Printf("matcha: desktop notifications disabled, %q is not installed or not on PATH (%v)", bin, err)
+		})
+		return fmt.Errorf("%w: %s", ErrNotifierMissing, bin)
+	}
+
+	return exec.Command(bin, args...).Run()
 }


### PR DESCRIPTION
### Problem

`notify.Send` runs `notify-send` (Linux) or `osascript` (macOS)
unconditionally:

```go
case "linux":
    return exec.Command("notify-send", title, body).Run()
```

On minimal Linux installs, Wayland-only setups, or systems without
AppleScript, those binaries are not on `PATH` and `exec.Command` fails
with a cryptic `executable file not found in $PATH` error. The one
caller in `main.go`:

```go
go notify.Send("Matcha", fmt.Sprintf("New mail in %s (%s)", ...))
```

spawns `Send` in a goroutine and drops the error, so the user never
sees a notification **and** has no log entry to explain why. #522.

### Fix

- Check `exec.LookPath` before invoking the binary.
- Log a single warning per process (`sync.Once`) when the notifier is
  missing, so the silent failure surfaces in the log once without
  spamming on every incoming email.
- Return a new `ErrNotifierMissing` sentinel so callers that *do* check
  the error can distinguish "no notifier installed" from "spawn
  failed".

Happy path (binary present) is unchanged.

```diff
+ var ErrNotifierMissing = errors.New("notify: platform notifier not installed")
+ var warnOnce sync.Once
+
  func Send(title, body string) error {
-     switch runtime.GOOS {
-     case "darwin":
-         script := fmt.Sprintf(`display notification %q with title %q sound name "default"`, body, title)
-         return exec.Command("osascript", "-e", script).Run()
-     case "linux":
-         return exec.Command("notify-send", title, body).Run()
-     default:
-         return nil
-     }
+     var bin string
+     var args []string
+     switch runtime.GOOS {
+     case "darwin": /* osascript + AppleScript */
+     case "linux":  /* notify-send */
+     default: return nil
+     }
+     if _, err := exec.LookPath(bin); err != nil {
+         warnOnce.Do(func() {
+             log.Printf("matcha: desktop notifications disabled, %q is not installed or not on PATH (%v)", bin, err)
+         })
+         return fmt.Errorf("%w: %s", ErrNotifierMissing, bin)
+     }
+     return exec.Command(bin, args...).Run()
  }
```

Fixes #522
