### PR TITLE
config/encryption: use crypto/subtle for sentinel comparison

### DIFF
--- a/config/encryption.go
+++ b/config/encryption.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -176,7 +177,13 @@ func VerifyPassword(password string) ([]byte, error) {
 		return nil, errors.New("incorrect password")
 	}
 
-	if string(plaintext) != sentinelPlaintext {
+	// subtle.ConstantTimeCompare short-circuits on length mismatch before
+	// doing the byte loop, but both the data-dependent length check and
+	// the early-exit inside `!=` on strings were measurable timing
+	// side-channels for the sentinel recovery (#659). Keep the comparison
+	// constant-time even though the input is small and cipher failure
+	// above already handles the common wrong-password case.
+	if subtle.ConstantTimeCompare(plaintext, []byte(sentinelPlaintext)) != 1 {
 		return nil, errors.New("incorrect password")
 	}
 


### PR DESCRIPTION
### Problem

`VerifyPassword` in `config/encryption.go` decrypts a fixed sentinel
string with the key derived from the user's password and then compares
the plaintext against the constant `sentinelPlaintext` with a plain
`!=`:

```go
if string(plaintext) != sentinelPlaintext {
    return nil, errors.New("incorrect password")
}
```

Go's `string !=` short-circuits on the first differing byte, and also
on any length mismatch before it starts comparing. The amount of time
`VerifyPassword` takes therefore varies with whatever plaintext the
attacker managed to produce — a classic CWE-208 timing side-channel
against an offline attacker who already has a copy of `secure.meta`.
#659.

### Fix

Swap in `subtle.ConstantTimeCompare` against a `[]byte`:

```diff
- if string(plaintext) != sentinelPlaintext {
+ if subtle.ConstantTimeCompare(plaintext, []byte(sentinelPlaintext)) != 1 {
      return nil, errors.New("incorrect password")
  }
```

Adds `crypto/subtle` to the imports. The common wrong-key case is
already caught by the `Decrypt` error branch above this block and
doesn't touch the compare, so the happy path and the common failure
path are both unaffected.

Fixes #659
