### PR TITLE
sender: validate recipient addresses before dialling SMTP

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/mail"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1972,6 +1973,18 @@ func sendEmail(account *config.Account, msg tui.SendEmailMsg) tea.Cmd {
 		recipients := splitEmails(msg.To)
 		cc := splitEmails(msg.Cc)
 		bcc := splitEmails(msg.Bcc)
+
+		// Validate recipient addresses before dialling SMTP. Without this, the
+		// SMTP server rejects them at RCPT TO with a cryptic protocol error
+		// that users can't act on.
+		for _, group := range [][]string{recipients, cc, bcc} {
+			for _, r := range group {
+				if _, err := mail.ParseAddress(r); err != nil {
+					return tui.EmailResultMsg{Err: fmt.Errorf("invalid email address %q: %w", r, err)}
+				}
+			}
+		}
+
 		body := msg.Body
 		// Append signature if present
 		if msg.Signature != "" {


### PR DESCRIPTION
## What

`sendEmail` in `main.go` handed the composer's `To`/`Cc`/`Bcc` strings straight to `sender.SendEmail` after `splitEmails`. The first thing that rejects a malformed address is the SMTP server itself, at `RCPT TO`, with whatever cryptic 5xx the provider feels like returning (e.g. `501 5.1.3 Bad recipient address syntax`). The composer surfaces that verbatim via `EmailResultMsg.Err`, which is awful UX: no indication of which field (To vs Cc vs Bcc) was wrong, no hint of which address was rejected.

Secondary concern: by the time that error comes back, we've already dialled the SMTP server, upgraded TLS, authenticated, and issued `MAIL FROM` plus at least one `RCPT TO`. Any valid recipient has been disclosed to the server. For a bounded validation fix it's worth doing the check before we open the socket at all.

Per #648.

## Fix

One loop over the three groups that splits already produced, running each through `net/mail.ParseAddress`. First failure short-circuits with a clear error:

```go
for _, group := range [][]string{recipients, cc, bcc} {
    for _, r := range group {
        if _, err := mail.ParseAddress(r); err != nil {
            return tui.EmailResultMsg{Err: fmt.Errorf("invalid email address %q: %w", r, err)}
        }
    }
}
```

`mail.ParseAddress` accepts the same shapes a user already types in the composer: bare `user@example.com` and `Name <user@example.com>` (RFC 5322). So valid addresses are unaffected; only genuinely malformed ones are caught.

Error path reuses the existing `EmailResultMsg.Err` plumbing — no new UI, no new message type, no flag. The composer already renders `EmailResultMsg.Err` on send failure.

## Not doing in this PR

Real-time validation in the composer's text-input widget. That's a larger UX change (inline red text, focus handling, debouncing). This PR keeps the fix bounded to the send path, which is where the cryptic SMTP error actually fires today.

Fixes #648