### PR TITLE
fix: validate PGPKeySource field on config load

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -565,6 +565,11 @@ func LoadConfig() (*Config, error) {
 			POP3Port:           rawAcc.POP3Port,
 		}
 
+		// Validate PGPKeySource
+		if acc.PGPKeySource != "" && acc.PGPKeySource != "file" && acc.PGPKeySource != "yubikey" {
+			return nil, fmt.Errorf("account %q: invalid pgp_key_source %q (must be \"file\" or \"yubikey\")", acc.Name, acc.PGPKeySource)
+		}
+
 		if secureMode {
 			// In secure mode, passwords and PINs are stored in the encrypted config JSON
 			acc.Password = rawAcc.Password


### PR DESCRIPTION
PGPKeySource accepted any string without validation. An invalid value like `pgp_key_source: "invalid"` would load successfully but cause silent failures when the code later assumes the value is `"file"` or `"yubikey"`.

Added validation in `LoadConfig()` immediately after the account struct is constructed. Now rejects invalid values with a clear error message at startup rather than failing silently at runtime.

Closes #620