### PR TITLE
feat(tui/login): add ctrl+v password visibility toggle

### DIFF
--- a/tui/login.go
+++ b/tui/login.go
@@ -176,6 +176,18 @@ func (m *Login) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "esc":
 			return m, func() tea.Msg { return GoToChoiceMenuMsg{} }
 
+		case "ctrl+v":
+			// Toggle password visibility while focused on the password field,
+			// so typos in app-passwords are catchable without retyping.
+			if m.focusIndex == inputPassword {
+				if m.inputs[inputPassword].EchoMode == textinput.EchoPassword {
+					m.inputs[inputPassword].EchoMode = textinput.EchoNormal
+				} else {
+					m.inputs[inputPassword].EchoMode = textinput.EchoPassword
+				}
+				return m, nil
+			}
+
 		case "enter":
 			m.updateFlags()
 			visible := m.visibleFields()
@@ -417,7 +429,11 @@ func (m *Login) View() tea.View {
 	if !m.hideTips && tip != "" {
 		views = append(views, TipStyle.Render("Tip: "+tip))
 	}
-	views = append(views, helpStyle.Render("\nenter: save • tab: next field • esc: back to menu"))
+	helpLine := "enter: save • tab: next field • esc: back to menu"
+	if m.focusIndex == inputPassword {
+		helpLine += " • ctrl+v: toggle password visibility"
+	}
+	views = append(views, helpStyle.Render("\n"+helpLine))
 
 	return tea.NewView(lipgloss.JoinVertical(lipgloss.Left, views...))
 }


### PR DESCRIPTION
Closes #593.

## Summary

Adds a `ctrl+v` chord on the Password / App Password field in `tui/login.go` to toggle between `textinput.EchoPassword` and `textinput.EchoNormal`. The chord only fires when the password input has focus; on any other field it falls through to normal input handling.

When the password field is focused, the existing help line under the form adds ` • ctrl+v: toggle password visibility` so the chord is discoverable without cluttering the view while other fields are focused.

## Why

Under `EchoPassword`, typos in long app-passwords are effectively invisible. The previous workaround was to delete and retype carefully; this just reveals the masked characters in place.

## Implementation notes

- The toggle is a direct `EchoMode` flip on `m.inputs[inputPassword]`, which matches the approach the issue body proposed. Returns `m, nil` so bubbletea doesn't also treat the chord as a regular keystroke into the input.
- `ctrl+v` was picked for consistency with common TUIs and because matcha doesn't already bind it (grep confirmed).
- Help-line addition is appended conditionally so it only appears while the password field is focused.

## Verification

```
go build ./...   ok
go vet ./...     ok
go test ./tui/   ok (0.368s)
```

Manual check: running the login form, typing into the password field, pressing `ctrl+v` flips the masked dots to plain text. Pressing again re-masks. Focus changes don't leak the reveal into other fields.

## AI assistance

This contribution was developed with AI assistance (Claude Code). Per matcha's `AI Policy`: I understand what was submitted, the change was verified via `go build`, `go vet`, and `go test ./tui/`, and the manual-check bullet above was the hands-on confirmation. No AI-generated tests were added for coverage padding.
