### PR TITLE
fix: check io.ReadAll errors (#713)

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -135,7 +135,10 @@ func deliveryHeadersMatch(data []byte, fetchEmail string) bool {
 func decodePart(reader io.Reader, header mail.PartHeader) (string, error) {
 	mediaType, params, err := mime.ParseMediaType(header.Get("Content-Type"))
 	if err != nil {
-		body, _ := ioutil.ReadAll(reader)
+		body, readErr := io.ReadAll(reader)
+		if readErr != nil {
+			return string(body), fmt.Errorf("fallback read after Content-Type parse error (%v): %w", err, readErr)
+		}
 		return string(body), nil
 	}
 
@@ -738,7 +741,11 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 								}
 								cType, _, _ := mime.ParseMediaType(p.Header.Get("Content-Type"))
 								disp, dParams, _ := mime.ParseMediaType(p.Header.Get("Content-Disposition"))
-								b, _ := ioutil.ReadAll(p.Body) // Auto-decodes quoted-printable/base64
+								b, readErr := io.ReadAll(p.Body) // Auto-decodes quoted-printable/base64
+								if readErr != nil {
+									log.Printf("fetcher: reading inner MIME part body: %v", readErr)
+									continue
+								}
 
 								if disp == "attachment" || disp == "inline" || (!strings.HasPrefix(cType, "multipart/") && cType != "text/plain" && cType != "text/html") {
 									fn := dParams["filename"]


### PR DESCRIPTION
## What?

Two call sites in `fetcher/fetcher.go` were discarding `io.ReadAll` errors. This PR surfaces those errors so callers can distinguish read failures from genuine missing content:

- `decodePart` (line 137): the Content-Type fallback path used to `body, _ := ioutil.ReadAll(reader)` and return `(body, nil)`. A read failure looked identical to "content-type unknown but body OK." Now the fallback captures the read error and returns it wrapped. Also swapped the deprecated `ioutil.ReadAll` for `io.ReadAll` on this line.
- Inner MIME part parser in the PGP-decrypt attachment branch (line 740): read errors on a single part used to be silently ignored, producing an empty `Attachment` or a missing text/html body. Now the error is logged via the existing `log` package and the part is skipped. Also swapped `ioutil.ReadAll` for `io.ReadAll` on this line.

The other `ioutil.ReadAll` call sites (lines 156, 188, 190) are outside #713's scope and left as-is.

## Why?

Fixes #713. The issue called out that discarding `io.ReadAll` errors leads to silent data loss or partial reads. Making the errors observable lets the upstream path decide how to handle them (retry, fail the fetch, or treat the part as missing) instead of collapsing every failure into a success.

Verified: `go build ./...` passes, `go vet ./...` clean for fetcher, `go test ./fetcher/...` ok.
