### PR TITLE
fix: enforce TLS 1.2 minimum version in IMAP and SMTP connections

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -263,6 +263,7 @@ func connectWithOptions(account *config.Account, extraOpts *imapclient.Options) 
 		TLSConfig: &tls.Config{
 			ServerName:         imapServer,
 			InsecureSkipVerify: account.Insecure,
+			MinVersion:         tls.VersionTLS12,
 		},
 	}
 	if extraOpts != nil {

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -637,6 +637,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 	tlsConfig := &tls.Config{
 		ServerName:         smtpServer,
 		InsecureSkipVerify: account.Insecure,
+		MinVersion:         tls.VersionTLS12,
 	}
 
 	var c *smtp.Client
@@ -834,6 +835,7 @@ func SendCalendarReply(account *config.Account, to []string, subject, plainBody 
 	tlsConfig := &tls.Config{
 		ServerName:         smtpServer,
 		InsecureSkipVerify: account.Insecure,
+		MinVersion:         tls.VersionTLS12,
 	}
 
 	var c *smtp.Client


### PR DESCRIPTION
## What?

Added `MinVersion: tls.VersionTLS12` to all three `tls.Config` instances that were missing it:

- `fetcher/fetcher.go:266` — IMAP connection TLS config
- `sender/sender.go:640` — `SendEmail` SMTP TLS config
- `sender/sender.go:838` — `SendCalendarReply` SMTP TLS config

## Why?

Fixes #727

All three TLS configurations omitted `MinVersion`, allowing Go to default to TLS 1.0 — a protocol deprecated since RFC 8996 (2021). Modern mail servers (Gmail, Outlook, etc.) all support TLS 1.2+, so this change rejects insecure legacy protocol negotiation without breaking compatibility.

Connections to servers that only support TLS 1.0/1.1 will now fail with a clear TLS error instead of silently negotiating an insecure session.

## Testing

- `go build ./fetcher/ ./sender/` — compiles clean
- `go test ./sender/` — all tests pass
- `go test ./fetcher/` — all tests pass