### PR TITLE
fix: use atomic increment for image ID allocation to prevent race condition

### DIFF
--- a/view/html.go
+++ b/view/html.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"charm.land/lipgloss/v2"
@@ -282,9 +283,7 @@ var nextImageID uint32 = 1000
 
 // allocImageID returns a unique Kitty image ID.
 func allocImageID() uint32 {
-	id := nextImageID
-	nextImageID++
-	return id
+	return atomic.AddUint32(&nextImageID, 1)
 }
 
 func fetchRemoteBase64(url string) string {

--- a/view/html_test.go
+++ b/view/html_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"charm.land/lipgloss/v2"
@@ -759,5 +761,46 @@ func TestRemoteImageCache_EvictsOldestWhenFull(t *testing.T) {
 		if _, ok := remoteImageCache.Get(keptURL); !ok {
 			t.Errorf("expected %q to still be in cache", keptURL)
 		}
+	}
+}
+
+func TestAllocImageID_NoRace(t *testing.T) {
+	// Reset the counter so IDs start from a known value.
+	atomic.StoreUint32(&nextImageID, 1000)
+
+	const goroutines = 100
+	const idsPerGoroutine = 100
+
+	results := make(chan uint32, goroutines*idsPerGoroutine)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range idsPerGoroutine {
+				results <- allocImageID()
+			}
+		}()
+	}
+
+	// Close channel once all writers are done.
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Collect all IDs and verify uniqueness.
+	seen := make(map[uint32]bool, goroutines*idsPerGoroutine)
+	for id := range results {
+		if seen[id] {
+			t.Fatalf("duplicate image ID allocated: %d (race condition detected)", id)
+		}
+		seen[id] = true
+	}
+
+	expected := uint32(goroutines * idsPerGoroutine)
+	if uint32(len(seen)) != expected {
+		t.Errorf("expected %d unique IDs, got %d", expected, len(seen))
 	}
 }


### PR DESCRIPTION
## What?

Replaced the non-atomic `nextImageID++` increment in `allocImageID()` with `atomic.AddUint32(&nextImageID, 1)`.

## Why?

Fixes #730

`allocImageID()` in `view/html.go` used a plain read-then-increment (`id := nextImageID; nextImageID++`) with no synchronization. When multiple goroutines process images concurrently (e.g., rendering an email with multiple inline images), they can:

1. Read the same value of `nextImageID`, allocating duplicate IDs
2. Lose updates entirely due to the non-atomic write

This would cause Kitty image protocol placements to conflict, resulting in broken image rendering. The race detector (`go test -race`) would flag this immediately.

The fix uses `sync/atomic.AddUint32` which is a single CPU instruction on most architectures — zero overhead.

## Testing

Added `TestAllocImageID_NoRace` which:
- Spawns 100 goroutines, each allocating 100 IDs concurrently
- Verifies all 10,000 IDs are unique (no duplicates)
- Would deterministically fail under the old code with `go test -race`