### PR TITLE
fix: use local time, and highlight dates

### DIFF
--- a/main.go
+++ b/main.go
@@ -1127,7 +1127,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !strings.HasPrefix(normalizedSubject, "re:") {
 			subject = "Re: " + subject
 		}
-		quotedText := fmt.Sprintf("\n\nOn %s, %s wrote:\n> %s", msg.Email.Date.Format("Jan 2, 2006 at 3:04 PM"), msg.Email.From, strings.ReplaceAll(msg.Email.Body, "\n", "\n> "))
+		quotedText := fmt.Sprintf("\n\nOn %s, %s wrote:\n> %s", msg.Email.Date.Local().Format("Jan 2, 2006 at 3:04 PM"), msg.Email.From, strings.ReplaceAll(msg.Email.Body, "\n", "\n> "))
 
 		var composer *tui.Composer
 		hideTips := false
@@ -1164,7 +1164,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		forwardHeader := fmt.Sprintf("\n\n---------- Forwarded message ----------\nFrom: %s\nDate: %s\nSubject: %s\nTo: %s\n\n",
 			msg.Email.From,
-			msg.Email.Date.Format("Mon, Jan 2, 2006 at 3:04 PM"),
+			msg.Email.Date.Local().Format("Mon, Jan 2, 2006 at 3:04 PM"),
 			msg.Email.Subject,
 			msg.Email.To,
 		)
@@ -2160,7 +2160,7 @@ func sendRSVP(account *config.Account, msg tui.SendRSVPMsg) tea.Cmd {
 		bodyText := fmt.Sprintf("%s: %s\n\n%s",
 			msg.Response,
 			msg.Event.Summary,
-			msg.Event.Start.Format("Mon Jan 2, 2006 3:04 PM"))
+			msg.Event.Start.Local().Format("Mon Jan 2, 2006 3:04 PM"))
 		if msg.Event.Location != "" {
 			bodyText += " at " + msg.Event.Location
 		}

--- a/tui/drafts.go
+++ b/tui/drafts.go
@@ -63,7 +63,7 @@ func formatTimeAgo(t time.Time) string {
 		}
 		return fmt.Sprintf("%d days ago", days)
 	default:
-		return t.Format("Jan 2, 2006")
+		return t.Local().Format("Jan 2, 2006")
 	}
 }
 

--- a/tui/email_view.go
+++ b/tui/email_view.go
@@ -478,6 +478,8 @@ func renderCalendarInvite(event *calendar.Event) string {
 
 // formatEventTime formats event start/end times
 func formatEventTime(start, end time.Time) string {
+	start = start.Local()
+	end = end.Local()
 	if start.Format("2006-01-02") == end.Format("2006-01-02") {
 		// Same day
 		return fmt.Sprintf("%s, %s - %s",

--- a/tui/inbox.go
+++ b/tui/inbox.go
@@ -79,16 +79,16 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 		layout = d.inbox.dateFormat
 	}
 	dateStr := formatRelativeDate(i.date, layout)
+	listWidth := m.Width()
+	isSelected := index == m.Index()
+
 	styledDate := dateStyle.Render(dateStr)
-	if i.isRead {
-		styledDate = readEmailStyle.Render(dateStr)
+	if isSelected {
+		styledDate = selectedItemStyle.Render(dateStr)
 	} else {
 		styledDate = statusStyle.Render(dateStr)
 	}
 	dateWidth := lipgloss.Width(styledDate)
-
-	listWidth := m.Width()
-	isSelected := index == m.Index()
 	cursorWidth := 0
 	if isSelected {
 		cursorWidth = 2 // "> " prefix
@@ -194,6 +194,7 @@ func formatRelativeDate(t time.Time, layout string) string {
 		}
 		return fmt.Sprintf("%d days ago", days)
 	default:
+		t = t.Local()
 		if layout != "" {
 			return t.Format(layout)
 		}


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Converts date to local time, and enables highlighting the dates for when the email is selected for better visibility.

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

Closes #646 