### PR TITLE
fix: load folders from cache

### DIFF
--- a/main.go
+++ b/main.go
@@ -387,8 +387,9 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
-		if len(cachedFolders) == 0 {
-			cachedFolders = []string{"INBOX"}
+		// Always ensure INBOX is present, even if cache is empty or stale
+		if !seen["INBOX"] {
+			cachedFolders = append([]string{"INBOX"}, cachedFolders...)
 		}
 		m.folderInbox = tui.NewFolderInbox(cachedFolders, m.config.Accounts)
 		m.folderInbox.SetDateFormat(m.config.GetDateFormat())


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Ensure INBOX is present, even if cache is empty or stale.

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

Sometimes email folders will not load, causing a 2-5 second delay to switch folders