### PR TITLE
fix: encryption settings not working

### DIFF
--- a/tui/settings_encryption.go
+++ b/tui/settings_encryption.go
@@ -34,6 +34,15 @@ func (m *Settings) updateEncryption(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg.String() {
+	case "esc":
+		// Clear inputs and return to menu
+		m.encPasswordInput.SetValue("")
+		m.encConfirmInput.SetValue("")
+		m.encPasswordInput.Blur()
+		m.encConfirmInput.Blur()
+		m.encError = ""
+		m.activePane = PaneMenu
+		return m, nil
 	case "tab", "shift+tab", "down", "up":
 		if msg.String() == "shift+tab" || msg.String() == "up" {
 			m.encFocusIndex--
@@ -85,6 +94,15 @@ func (m *Settings) updateEncryption(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return SecureModeEnabledMsg{Err: err}
 			}
 		}
+	default:
+		// Forward input to focused textinput
+		var cmd tea.Cmd
+		if m.encFocusIndex == 0 {
+			m.encPasswordInput, cmd = m.encPasswordInput.Update(msg)
+		} else if m.encFocusIndex == 1 {
+			m.encConfirmInput, cmd = m.encConfirmInput.Update(msg)
+		}
+		return m, cmd
 	}
 	return m, nil
 }


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Fixed a bug, where, if you go to encryption settings menu, you cannot enter the password, nor navigate. Also, fixed `esc` key handling.


## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

`updateEncryption` handles keys but doesn't forward input to textinput fields. Only navigation/enter handled, not typing.