### PR TITLE
fix: check Close() in debug logger

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -1035,7 +1035,9 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 		if path := os.Getenv("DEBUG_KITTY_LOG"); path != "" {
 			if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
 				_, _ = f.WriteString(msg)
-				_ = f.Close()
+				if closeErr := f.Close(); closeErr != nil {
+					log.Printf("warning: failed to close kitty debug log: %v", closeErr)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What?

Added error check on `f.Close()` in the Kitty debug image logger (`fetcher/fetcher.go`). Previously the error was silently discarded with `_`.

## Why?

Fixes #819

If the close fails (e.g., disk full, NFS error), the written data may not be flushed to disk. The developer would never know their debug log is incomplete. Now logs a warning on close failure.

## Testing

- `go build ./fetcher/` — compiles clean