### PR TITLE
fix: use crypto/rand for MIME boundary

### DIFF
--- a/pgp/yubikey.go
+++ b/pgp/yubikey.go
@@ -3,6 +3,7 @@ package pgp
 import (
 	"bytes"
 	"crypto"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -93,7 +94,7 @@ func BuildPGPSignedMessage(payload []byte, pin string, publicKeyPath string) ([]
 	headers, body := splitPayload(payload)
 
 	// Build the signed body part (this is what gets hashed)
-	boundary := fmt.Sprintf("----=_Part_%d", time.Now().Unix())
+	boundary := generateBoundary()
 	signedPart := buildSignedPart(headers, body, boundary)
 
 	// Build the OpenPGP signature packet
@@ -503,4 +504,14 @@ func GetYubiKeyInfo() (string, error) {
 	}
 
 	return info, nil
+}
+
+// generateBoundary creates a cryptographically random MIME boundary string.
+func generateBoundary() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err == nil {
+		return fmt.Sprintf("----=_Part_%x", buf)
+	}
+	// Fallback to timestamp if crypto/rand fails (extremely unlikely)
+	return fmt.Sprintf("----=_Part_%d", time.Now().UnixNano())
 }


### PR DESCRIPTION
## What?

Replaced `time.Now().Unix()` with `crypto/rand` for MIME boundary generation in `pgp/yubikey.go`.

## Why?

Fixes #729

The MIME boundary used a Unix timestamp, which is trivially predictable. While MIME boundary prediction has limited attack surface, `sender/sender.go` already uses `crypto/rand` for its boundaries. This brings `yubikey.go` in line with the established pattern.

Falls back to `time.Now().UnixNano()` if `crypto/rand` is unavailable (extremely unlikely).

## Testing

- `go build ./pgp/` — compiles clean