### PR TITLE
fix: check tmpFile Close() error

### DIFF
--- a/main.go
+++ b/main.go
@@ -2250,7 +2250,12 @@ func openExternalEditor(body string) tea.Cmd {
 			return tui.EditorFinishedMsg{Err: fmt.Errorf("writing temp file: %w", err)}
 		}
 	}
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		return func() tea.Msg {
+			return tui.EditorFinishedMsg{Err: fmt.Errorf("closing temp file: %w", err)}
+		}
+	}
 
 	parts := strings.Fields(editor)
 	args := append(parts[1:], tmpPath)


### PR DESCRIPTION
## What?

Added error check on `tmpFile.Close()` in the external editor flow (`main.go`). Previously the error was ignored, so the editor could open with incomplete or empty content.

## Why?

Fixes #728

If `Close()` fails (e.g., disk full), data written via `WriteString()` may not be persisted to disk. The editor would then open an empty file, and the user could lose their draft content. Now returns an error to the UI instead of proceeding.

## Testing

- `go build .` — compiles clean