### PR TITLE
fix: check Chmod error on daemon socket

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -97,7 +97,9 @@ func (d *Daemon) Run() error {
 	defer d.listener.Close()
 
 	// Set socket permissions (owner only).
-	os.Chmod(sockPath, 0700)
+	if err := os.Chmod(sockPath, 0700); err != nil {
+		log.Printf("warning: failed to set socket permissions on %s: %v", sockPath, err)
+	}
 
 	log.Printf("daemon: listening on %s (PID %d)", sockPath, os.Getpid())
 


### PR DESCRIPTION
## What?

Added error check on `os.Chmod(sockPath, 0700)` in `daemon/daemon.go`. Logs a warning if setting socket permissions fails.

## Why?

Fixes #714

If Chmod fails, the socket may be world-accessible. Silent failure means the operator never knows the daemon is running with insecure permissions.

## Testing

- `go build ./daemon/` — compiles clean