### PR TITLE
fix: use Lstat in filepicker

### DIFF
--- a/tui/filepicker.go
+++ b/tui/filepicker.go
@@ -91,7 +91,7 @@ func (m *FilePicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						path = filepath.Join(home, path[1:])
 					}
 				}
-				info, err := os.Stat(path)
+				info, err := os.Lstat(path)
 				if err == nil {
 					if info.IsDir() {
 						m.currentPath = path


### PR DESCRIPTION
## What?

Changed `os.Stat(path)` to `os.Lstat(path)` in `tui/filepicker.go` when resolving pasted paths.

## Why?

Fixes #803

`os.Stat` follows symlinks, allowing a crafted symlink (e.g. `~/.config/matcha/link → /etc`) to navigate into arbitrary directories. `os.Lstat` returns info about the symlink itself without following it, preventing traversal.

## Testing

- `go build ./tui/` — compiles clean