### PR TITLE
fix: check ReadAll on decrypted body

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -891,11 +891,17 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 								case *mail.InlineHeader:
 									ct, _, _ := h.ContentType()
 									if strings.HasPrefix(ct, "text/html") {
-										body, _ := io.ReadAll(p.Body)
+										body, readErr := io.ReadAll(p.Body)
+										if readErr != nil {
+											log.Printf("warning: failed to read decrypted HTML body: %v", readErr)
+										}
 										extractedBody = string(body)
 										htmlPartID = "decrypted"
 									} else if strings.HasPrefix(ct, "text/plain") && extractedBody == "" {
-										body, _ := io.ReadAll(p.Body)
+										body, readErr := io.ReadAll(p.Body)
+										if readErr != nil {
+											log.Printf("warning: failed to read decrypted plain body: %v", readErr)
+										}
 										extractedBody = string(body)
 										htmlPartID = "decrypted"
 									}


### PR DESCRIPTION
## What?

Added error checks on two `io.ReadAll(p.Body)` calls in the decrypted PGP/MIME body extraction path in `fetcher/fetcher.go`. Logs a warning on failure instead of silently discarding.

## Why?

Fixes #713

When reading decrypted HTML/plain text bodies, `io.ReadAll` errors were discarded with `_`. A failed read would produce empty or partial content with no indication something went wrong.

## Testing

- `go build ./fetcher/` — compiles clean