### PR TITLE
fix: check Unmarshal in daemon tests

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -99,7 +99,9 @@ func TestDaemon_PingHandler(t *testing.T) {
 		t.Fatal("expected Response")
 	}
 	var result daemonrpc.PingResult
-	json.Unmarshal(msg.Response.Result, &result)
+	if err := json.Unmarshal(msg.Response.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
 	if !result.Pong {
 		t.Error("expected pong=true")
 	}
@@ -115,7 +117,9 @@ func TestDaemon_StatusHandler(t *testing.T) {
 	msg := handlerTest(t, d, &daemonrpc.Request{ID: 1, Method: daemonrpc.MethodGetStatus})
 
 	var result daemonrpc.StatusResult
-	json.Unmarshal(msg.Response.Result, &result)
+	if err := json.Unmarshal(msg.Response.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
 
 	if !result.Running {
 		t.Error("expected running=true")


### PR DESCRIPTION
## What?

Added error checks on two `json.Unmarshal()` calls in `daemon/daemon_test.go`. Tests now fail fast with a clear message instead of continuing with zero-value structs.

## Why?

Fixes #718

If unmarshaling fails, tests would continue with empty structs, producing confusing assertion failures downstream. Now fails immediately at the source.

## Testing

- `go test ./daemon/` — all tests pass