### PR TITLE
fix: check Remove on stale socket

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -86,7 +86,9 @@ func (d *Daemon) Run() error {
 
 	// Remove stale socket file.
 	sockPath := daemonrpc.SocketPath()
-	os.Remove(sockPath)
+	if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove stale socket %s: %w", sockPath, err)
+	}
 
 	// Listen on Unix domain socket.
 	var err error


### PR DESCRIPTION
## What?

Added error check on `os.Remove(sockPath)` when cleaning the stale daemon socket. Returns a clear error if removal fails for reasons other than "file not found".

## Why?

Fixes #719

If `os.Remove` fails due to permissions, the subsequent `net.Listen` fails with a confusing "address already in use" error. Now returns a descriptive message. `os.IsNotExist` is ignored since no stale file means no cleanup needed.

## Testing

- `go build ./daemon/` — compiles clean