### PR TITLE
feat: email priority flag

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -116,6 +116,7 @@ type OutgoingEmail struct {
 	EncryptSMIME bool
 	SignPGP      bool
 	EncryptPGP   bool
+	Priority     int // 1=high, 3=normal, 5=low
 }
 
 // NotifyType indicates the kind of notification event.

--- a/backend/imap/imap.go
+++ b/backend/imap/imap.go
@@ -84,6 +84,7 @@ func (p *Provider) SendEmail(_ context.Context, msg *backend.OutgoingEmail) erro
 		msg.InReplyTo, msg.References,
 		msg.SignSMIME, msg.EncryptSMIME,
 		msg.SignPGP, msg.EncryptPGP,
+		msg.Priority,
 	)
 	if err != nil {
 		return err

--- a/backend/pop3/pop3.go
+++ b/backend/pop3/pop3.go
@@ -231,6 +231,7 @@ func (p *Provider) SendEmail(_ context.Context, msg *backend.OutgoingEmail) erro
 		msg.InReplyTo, msg.References,
 		msg.SignSMIME, msg.EncryptSMIME,
 		msg.SignPGP, msg.EncryptPGP,
+		msg.Priority,
 	)
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -2176,7 +2176,7 @@ func sendEmail(account *config.Account, msg tui.SendEmailMsg) tea.Cmd {
 			attachments[filename] = fileData
 		}
 
-		rawMsg, err := sender.SendEmail(account, recipients, cc, bcc, msg.Subject, body, string(htmlBody), images, attachments, msg.InReplyTo, msg.References, msg.SignSMIME, msg.EncryptSMIME, msg.SignPGP, false)
+		rawMsg, err := sender.SendEmail(account, recipients, cc, bcc, msg.Subject, body, string(htmlBody), images, attachments, msg.InReplyTo, msg.References, msg.SignSMIME, msg.EncryptSMIME, msg.SignPGP, false, msg.Priority)
 		if err != nil {
 			log.Printf("Failed to send email: %v", err)
 			return tui.EmailResultMsg{Err: err}
@@ -3048,7 +3048,7 @@ func runSendCLI(args []string) {
 	ccList := splitEmails(*cc)
 	bccList := splitEmails(*bcc)
 
-	rawMsg, sendErr := sender.SendEmail(account, recipients, ccList, bccList, *subject, emailBody, string(htmlBody), images, attachMap, "", nil, *signSMIME, *encryptSMIME, *signPGP, false)
+	rawMsg, sendErr := sender.SendEmail(account, recipients, ccList, bccList, *subject, emailBody, string(htmlBody), images, attachMap, "", nil, *signSMIME, *encryptSMIME, *signPGP, false, 3)
 	if sendErr != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", sendErr)
 		os.Exit(1)

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -155,7 +155,7 @@ func detectPlaintextOnly(body string, images, attachments map[string][]byte) boo
 }
 
 // SendEmail constructs a multipart message with plain text, HTML, embedded images, and attachments.
-func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody, htmlBody string, images map[string][]byte, attachments map[string][]byte, inReplyTo string, references []string, signSMIME bool, encryptSMIME bool, signPGP bool, encryptPGP bool) ([]byte, error) {
+func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody, htmlBody string, images map[string][]byte, attachments map[string][]byte, inReplyTo string, references []string, signSMIME bool, encryptSMIME bool, signPGP bool, encryptPGP bool, priority int) ([]byte, error) {
 	smtpServer := account.GetSMTPServer()
 	smtpPort := account.GetSMTPPort()
 
@@ -176,6 +176,23 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 		"Date":         time.Now().Format(time.RFC1123Z),
 		"Message-ID":   generateMessageID(account.GetSendAsEmail()),
 		"MIME-Version": "1.0",
+	}
+
+	// Set priority headers if non-default (3 = normal, which is the default)
+	if priority == 1 {
+		headers["X-Priority"] = "1 (Highest)"
+		headers["Importance"] = "high"
+		headers["X-MSMail-Priority"] = "High"
+	} else if priority == 2 {
+		headers["X-Priority"] = "2 (High)"
+		headers["Importance"] = "high"
+	} else if priority == 4 {
+		headers["X-Priority"] = "4 (Low)"
+		headers["Importance"] = "low"
+	} else if priority == 5 {
+		headers["X-Priority"] = "5 (Lowest)"
+		headers["Importance"] = "low"
+		headers["X-MSMail-Priority"] = "Low"
 	}
 
 	if len(cc) > 0 {

--- a/tui/composer.go
+++ b/tui/composer.go
@@ -41,6 +41,7 @@ const (
 	focusSignature
 	focusAttachment
 	focusEncryptSMIME
+	focusPriority
 	focusSend
 )
 
@@ -55,6 +56,7 @@ type Composer struct {
 	signatureInput  textarea.Model
 	attachmentPaths []string
 	encryptSMIME    bool
+	priority        int // 1=high, 3=normal, 5=low
 	width           int
 	height          int
 	confirmingExit  bool
@@ -419,6 +421,20 @@ func (m *Composer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 
+			case focusPriority:
+				if msg.String() == "enter" || msg.String() == " " {
+					// Cycle: normal(3) -> high(1) -> low(5) -> normal(3)
+					switch m.priority {
+					case 3, 0:
+						m.priority = 1
+					case 1, 2:
+						m.priority = 5
+					default:
+						m.priority = 3
+					}
+				}
+				return m, nil
+
 			case focusSend:
 				if msg.String() == "enter" {
 					acc := m.getSelectedAccount()
@@ -442,6 +458,7 @@ func (m *Composer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 							SignSMIME:       acc != nil && acc.SMIMESignByDefault,
 							EncryptSMIME:    m.encryptSMIME,
 							SignPGP:         acc != nil && acc.PGPSignByDefault,
+							Priority:        m.priority,
 						}
 					}
 				}
@@ -547,6 +564,27 @@ func (m *Composer) View() tea.View {
 		encField = focusedStyle.Render(fmt.Sprintf("> %s %s", t("composer.encrypt_smime"), encToggle))
 	}
 
+	priorityLabel := "Normal"
+	priorityIcon := "\u2B24" // circle
+	switch m.priority {
+	case 1:
+		priorityLabel = "High"
+		priorityIcon = "\U0001F534" // red circle
+	case 2:
+		priorityLabel = "Medium-High"
+		priorityIcon = "\U0001F7E0" // orange circle
+	case 4:
+		priorityLabel = "Medium-Low"
+		priorityIcon = "\U0001F7E1" // yellow circle
+	case 5:
+		priorityLabel = "Low"
+		priorityIcon = "\U0001F535" // blue circle
+	}
+	priorityField := blurredStyle.Render(fmt.Sprintf("  Priority: %s %s", priorityIcon, priorityLabel))
+	if m.focusIndex == focusPriority {
+		priorityField = focusedStyle.Render(fmt.Sprintf("> Priority: %s %s", priorityIcon, priorityLabel))
+	}
+
 	// Build To field with suggestions
 	toFieldView := m.toInput.View()
 	if m.showSuggestions && len(m.suggestions) > 0 {
@@ -609,6 +647,7 @@ func (m *Composer) View() tea.View {
 		m.signatureInput.View(),
 		attachmentStyle.Render(attachmentField),
 		smimeToggleStyle.Render(encField),
+		smimeToggleStyle.Render(priorityField),
 		button,
 		"",
 	}

--- a/tui/composer_test.go
+++ b/tui/composer_test.go
@@ -71,11 +71,18 @@ func TestComposerUpdate(t *testing.T) {
 			t.Errorf("After seven Tabs, focusIndex should be %d (focusEncryptSMIME), got %d", focusEncryptSMIME, composer.focusIndex)
 		}
 
+		// Simulate pressing Tab to move to the 'Priority' field.
+		model, _ = composer.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+		composer = model.(*Composer)
+		if composer.focusIndex != focusPriority {
+			t.Errorf("After eight Tabs, focusIndex should be %d (focusPriority), got %d", focusPriority, composer.focusIndex)
+		}
+
 		// Simulate pressing Tab again to move to the 'Send' button.
 		model, _ = composer.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 		composer = model.(*Composer)
 		if composer.focusIndex != focusSend {
-			t.Errorf("After eight Tabs, focusIndex should be %d (focusSend), got %d", focusSend, composer.focusIndex)
+			t.Errorf("After nine Tabs, focusIndex should be %d (focusSend), got %d", focusSend, composer.focusIndex)
 		}
 
 		// Simulate one more Tab to wrap around.
@@ -83,7 +90,7 @@ func TestComposerUpdate(t *testing.T) {
 		model, _ = composer.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 		composer = model.(*Composer)
 		if composer.focusIndex != focusTo {
-			t.Errorf("After nine Tabs, focusIndex should wrap to %d (focusTo) since single account skips From, got %d", focusTo, composer.focusIndex)
+			t.Errorf("After ten Tabs, focusIndex should wrap to %d (focusTo) since single account skips From, got %d", focusTo, composer.focusIndex)
 		}
 	})
 
@@ -211,7 +218,9 @@ func TestComposerUpdate(t *testing.T) {
 		multiComposer = model.(*Composer)
 		model, _ = multiComposer.Update(tea.KeyPressMsg{Code: tea.KeyTab}) // Attachment -> EncryptSMIME
 		multiComposer = model.(*Composer)
-		model, _ = multiComposer.Update(tea.KeyPressMsg{Code: tea.KeyTab}) // EncryptSMIME -> Send
+		model, _ = multiComposer.Update(tea.KeyPressMsg{Code: tea.KeyTab}) // EncryptSMIME -> Priority
+		multiComposer = model.(*Composer)
+		model, _ = multiComposer.Update(tea.KeyPressMsg{Code: tea.KeyTab}) // Priority -> Send
 		multiComposer = model.(*Composer)
 		model, _ = multiComposer.Update(tea.KeyPressMsg{Code: tea.KeyTab}) // Send -> From (wrap)
 		multiComposer = model.(*Composer)
@@ -220,7 +229,7 @@ func TestComposerUpdate(t *testing.T) {
 
 		// With multiple accounts, From field should be included in tab order
 		if multiComposer.focusIndex != focusTo {
-			t.Errorf("After ten Tabs with multi-account, focusIndex should wrap to %d (focusTo), got %d", focusTo, multiComposer.focusIndex)
+			t.Errorf("After twelve Tabs with multi-account, focusIndex should wrap to %d (focusTo), got %d", focusTo, multiComposer.focusIndex)
 		}
 	})
 }

--- a/tui/messages.go
+++ b/tui/messages.go
@@ -38,6 +38,7 @@ type SendEmailMsg struct {
 	SignSMIME       bool   // Whether to sign the email using S/MIME
 	EncryptSMIME    bool   // Whether to encrypt the email using S/MIME
 	SignPGP         bool   // Whether to sign the email using PGP
+	Priority        int    // Email priority: 1=high, 3=normal (default), 5=low
 }
 
 type Credentials struct {


### PR DESCRIPTION
## What?

Adds email priority/importance selection in the composer. Cycles through Normal → High → Low with emoji indicators.

**Changes:**
- Priority toggle in composer tab order (after S/MIME, before Send)
- `X-Priority`, `Importance`, `X-MSMail-Priority` headers in sender
- Priority threaded through `SendEmailMsg` → backend → `SendEmail()` call sites
- Red circle (High), Blue circle (Low), Normal default

## Why?

Fixes #790

RFC 2156 defines priority headers. Most email clients support them. Users could not mark emails as urgent or low priority before sending.

## Testing

- `go build .` — compiles clean
- `go test ./tui/` — all tests pass (updated focus cycling tests for new tab)