### PR TITLE
fix: unchecked error on ReadAll

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -185,9 +185,17 @@ func decodeAttachmentData(rawBytes []byte, encoding string) ([]byte, error) {
 	switch strings.ToLower(encoding) {
 	case "base64":
 		decoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(rawBytes))
-		return ioutil.ReadAll(decoder)
+		data, err := ioutil.ReadAll(decoder)
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
 	case "quoted-printable":
-		return ioutil.ReadAll(quotedprintable.NewReader(bytes.NewReader(rawBytes)))
+		data, err := ioutil.ReadAll(quotedprintable.NewReader(bytes.NewReader(rawBytes)))
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
 	default:
 		return rawBytes, nil
 	}


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Properly handle errors from ioutil.ReadAll in decodeAttachmentData.

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

Fixes #750 — unchecked errors caused silent failures when readers encounter errors.

> ORIGINALLY DONE BY @gittihub-jpg, accidentally erased because of a contributors master branch