### PR TITLE
fix: defer kitty debug-log Close

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -1041,10 +1041,16 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 		msg := fmt.Sprintf("[kitty-img] body selection html=%s plain=%s chosen=%s\n", htmlPartID, plainPartID, textPartID)
 		log.Print(msg)
 		if path := os.Getenv("DEBUG_KITTY_LOG"); path != "" {
-			if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
+			// Use a closure with defer so a panic between open and
+			// WriteString doesn't leak the file descriptor (#894).
+			func() {
+				f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+				if err != nil {
+					return
+				}
+				defer f.Close()
 				_, _ = f.WriteString(msg)
-				_ = f.Close()
-			}
+			}()
 		}
 	}
 	if textPartID != "" {


### PR DESCRIPTION
## What?

Wrap open/write/close of the `DEBUG_KITTY_LOG` file in `fetcher/fetcher.go` in a closure with `defer f.Close()` so the file descriptor is always released, even if `WriteString` panics or returns mid-call.

## Why?

The original `OpenFile` -> `WriteString` -> `Close` sequence was inline. A panic (or any non-local exit) between `OpenFile` and `Close` leaked the descriptor. The long-lived `getDebugIMAPWriter` handle at `fetcher.go:45` stays as-is (intentional, stored on the package-level `debugIMAPFile`).

Fixes #894.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./fetcher/...`