### PR TITLE
ci: exclude all prereleases

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -8,7 +8,7 @@ jobs:
   notify-discord:
     name: Notify Discord Channel
     runs-on: ubuntu-latest
-    if: github.event.release.tag_name != 'nightlyv0'
+    if: github.event.release.prerelease == false
 
     steps:
       - name: Send Discord Message


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Excludes all prereleases from discord release webhook.

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

PR previews were posted in the #release channel on discord, even though they didn't need to