### PR TITLE
fix: nil check in renderCalendarInvite

### DIFF
--- a/tui/email_view.go
+++ b/tui/email_view.go
@@ -468,6 +468,10 @@ func (m *EmailView) GetEmail() fetcher.Email {
 
 // renderCalendarInvite renders a calendar invite card
 func renderCalendarInvite(event *calendar.Event) string {
+	if event == nil {
+		return ""
+	}
+
 	style := lipgloss.NewStyle().
 		Border(lipgloss.DoubleBorder()).
 		BorderForeground(theme.ActiveTheme.Accent).


### PR DESCRIPTION
## What?

Adds a nil check on the calendar event parameter in `renderCalendarInvite` to prevent potential runtime panics when the event data is unexpectedly nil.

## Why?

Without this check, calling `renderCalendarInvite` with a nil event could cause a crash. This fix ensures safe handling of nil calendar events, improving robustness.

Fixes #883
