### PR TITLE
ci: exclude preview from commit log

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -118,7 +118,7 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         run: |
           SHORT_SHA="$(git rev-parse --short HEAD)"
-          LATEST_TAG="$(git describe --tags --abbrev=0 --exclude='nightlyv*' 2>/dev/null || echo '')"
+          LATEST_TAG="$(git describe --tags --abbrev=0 --exclude='nightlyv*' --exclude='preview*' 2>/dev/null || echo '')"
 
           NOTES_FILE="$RUNNER_TEMP/release_notes.md"
           {


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Adds `exclude="preview*"` to the latest version fetching 

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

Nightly releases changelog was being compared to the preview PR versions.