### PR TITLE
perf: use slices instead of bubblesort

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -17,6 +17,7 @@ import (
 	"net/textproto"
 	"os"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -502,13 +503,9 @@ func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset u
 		}
 
 		// Sort batch Newest -> Oldest by UID desc
-		for i := 0; i < len(batchEmails); i++ {
-			for j := i + 1; j < len(batchEmails); j++ {
-				if batchEmails[j].UID > batchEmails[i].UID {
-					batchEmails[i], batchEmails[j] = batchEmails[j], batchEmails[i]
-				}
-			}
-		}
+		sort.Slice(batchEmails, func(i, j int) bool {
+			return batchEmails[i].UID > batchEmails[j].UID
+		})
 
 		allEmails = append(allEmails, batchEmails...)
 		cursor = from - 1


### PR DESCRIPTION
## What?

Replaced the manual nested loop sorting logic in `fetcher/fetcher.go` with `sort.Slice` using a descending UID comparator.

## Why?

The previous implementation was quadratic `O(n²)` on every batch. While the default chunk size of `50` kept this impact minimal, it becomes a dominant cost of the fetch operation when larger limits are used. Moving to `sort.Slice` provides `O(n × log n)` performance.

Closes #1080 