### PR TITLE
fix(cache): Add log email cache errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -733,12 +733,17 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					Inline:    a.Inline,
 				})
 			}
-			go config.SaveEmailBody(folderName, config.CachedEmailBody{
-				UID:         msg.UID,
-				AccountID:   msg.AccountID,
-				Body:        msg.Body,
-				Attachments: cachedAttachments,
-			})
+			go func() {
+				err := config.SaveEmailBody(folderName, config.CachedEmailBody{
+					UID:         msg.UID,
+					AccountID:   msg.AccountID,
+					Body:        msg.Body,
+					Attachments: cachedAttachments,
+				})
+				if err != nil {
+					log.Printf("debug: error caching email body fails (disk full, permission denied) for UID: %d: %v", msg.UID, err)
+				}
+			}()
 		}
 		// Forward to FolderInbox for rendering
 		if m.folderInbox != nil {

--- a/main.go
+++ b/main.go
@@ -1260,12 +1260,16 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			cachedAttachments = append(cachedAttachments, ca)
 		}
-		_ = config.SaveEmailBody(folderForCache, config.CachedEmailBody{
+		err := config.SaveEmailBody(folderForCache, config.CachedEmailBody{
 			UID:         msg.UID,
 			AccountID:   msg.AccountID,
 			Body:        msg.Body,
 			Attachments: cachedAttachments,
 		})
+
+		if err != nil {
+			log.Printf("debug: error caching email body fails (disk full, permission denied) for UID: %d: %v", msg.UID, err)
+		}
 
 		email := m.getEmailByUIDAndAccount(msg.UID, msg.AccountID, msg.Mailbox)
 		if email == nil {


### PR DESCRIPTION
## What?

Added error handling and logging to email body caching operations in `main.go`. Previously, `config.SaveEmailBody()` calls were ignoring errors with `_`, now they capture and log failures for both synchronous and asynchronous caching scenarios.

**Code changes:**
```go
// Before (synchronous):
_ = config.SaveEmailBody(folderForCache, config.CachedEmailBody{...})

// After (synchronous):
err := config.SaveEmailBody(folderForCache, config.CachedEmailBody{...})
if err != nil {
    log.Printf("debug: error caching email body fails (disk full, permission denied) for UID: %d: %v", msg.UID, err)
}

// Before (asynchronous):
go config.SaveEmailBody(folderName, config.CachedEmailBody{...})

// After (asynchronous):
go func() {
    err := config.SaveEmailBody(folderName, config.CachedEmailBody{...})
    if err != nil {
        log.Printf("debug: error caching email body fails (disk full, permission denied) for UID: %d: %v", msg.UID, err)
    }
}()
```

## Why?

Email body caching could fail silently due to disk full or permission denied errors, making debugging difficult when users experienced missing cached emails. This change adds visibility into caching failures to help diagnose storage-related issues.

closes: #1030 