### PR TITLE
fix: handle zero terminal cell height

### DIFF
--- a/view/html.go
+++ b/view/html.go
@@ -509,6 +509,9 @@ func imageRows(payload string) int {
 	if data, err := base64.StdEncoding.DecodeString(payload); err == nil {
 		if _, h, ok := clib.ImageDimensions(data); ok {
 			cellHeight := getTerminalCellSize()
+			if cellHeight == 0 {
+				cellHeight = 16
+			}
 			rows = (h + cellHeight - 1) / cellHeight
 			if rows < 1 {
 				rows = 1


### PR DESCRIPTION
## What?

Added a check for `cellHeight == 0` in the `imageRows` function within `view/html.go`. If the terminal height cannot be determined, it now defaults to a standard `16px` fallback.

## Why?

When running in terminals that don't report cell size via `ioctl`, `getTerminalCellSize()` returns `0`. This previously caused a "division by zero" runtime panic during the row calculation for inline images: `(h + cellHeight - 1) / cellHeight`.

Closes #865 