### PR TITLE
fix(cache): trim <> from email keys

### DIFF
--- a/config/cache.go
+++ b/config/cache.go
@@ -149,7 +149,7 @@ func LoadContactsCache() (*ContactsCache, error) {
 }
 
 func normalizeContactEmail(email string) string {
-	return strings.ToLower(strings.Trim(strings.TrimSpace(email), ","))
+	return strings.ToLower(strings.Trim(strings.TrimSpace(email), ",<>"))
 }
 
 // AddContact adds or updates a contact in the cache.


### PR DESCRIPTION
## What?

Add `<` and `>` to the trim cutset in `normalizeContactEmail` so the cache key is the bare email regardless of whether the input came from a header or a UI field. Whitespace and commas continue to be trimmed.

## Why?

Email addresses arriving from `From:` headers commonly come wrapped in angle brackets (`<foo@bar.com>`). The previous trim cutset was `,` only, so the cache stored the literal `<foo@bar.com>` and never matched future lookups against `foo@bar.com`.

Resolves #1122.