### PR TITLE
fix: change read path in i18n loader

### DIFF
--- a/i18n/loader.go
+++ b/i18n/loader.go
@@ -3,6 +3,7 @@ package i18n
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -35,8 +36,8 @@ func loadFromEmbedded(bundle *Bundle) error {
 			continue
 		}
 
-		// Read file
-		data, err := localeFS.ReadFile(filepath.Join("locales", filename))
+		// Read file (embed.FS always uses forward slashes, even on Windows)
+		data, err := localeFS.ReadFile(path.Join("locales", filename))
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## What?

<!-- Describe what this PR changes. Keep it concise — what code was added, removed, or modified? -->

Uses a different way to read locales in the `i18n` package.

The problem was with Windows compatibility, it returned an error, because couldn't reach the file 

## Why?

<!-- Explain the motivation behind this change. What problem does it solve, or what addition does it enable? Link related issues if applicable. -->

Closes #1192 
