### PR TITLE
fix(i18n): wrap original error in i18n

### DIFF
--- a/i18n/parser.go
+++ b/i18n/parser.go
@@ -15,7 +15,7 @@ type TranslationFile struct {
 func ParseJSON(data []byte) (MessageMap, error) {
 	var file TranslationFile
 	if err := json.Unmarshal(data, &file); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrParseFailed, err)
+		return nil, fmt.Errorf("%w: %w", ErrParseFailed, err)
 	}
 
 	messages := make(MessageMap)


### PR DESCRIPTION
## What?

Replaced the `%v` verb with `%w` in `i18n/parser.go` when returning errors from the parser.

## Why?

The previous implementation only wrapped `ErrParseFailed`. By rendering the underlying err as a string (`%v`), the error chain was broken. This prevented callers from using `errors.Is()` or `errors.As()` to detect the original cause of the failure. Using double `%w` (supported in Go 1.20+) ensures both the sentinel error and the root cause remain accessible in the error tree.
 