### PR TITLE
fix(i18n): wrap error in loader

### DIFF
--- a/i18n/loader.go
+++ b/i18n/loader.go
@@ -13,7 +13,7 @@ import (
 func LoadTranslations(bundle *Bundle) error {
 	// Load from embedded files
 	if err := loadFromEmbedded(bundle); err != nil {
-		return fmt.Errorf("%w: embedded load failed: %v", ErrLoadFailed, err)
+		return fmt.Errorf("%w: embedded load failed: %w", ErrLoadFailed, err)
 	}
 
 	return nil


### PR DESCRIPTION
## What?

Replaced the `%v` verb with `%w` in `i18n/loader.go` when returning errors from the embedded loader.

## Why?

The current implementation stringifies the underlying `err` using `%v`, which breaks the error chain. This prevents callers from inspecting the root cause using `errors.Is()` or `errors.As()`. Utilizing double `%w` (supported in Go 1.20+) ensures both `ErrLoadFailed` and the original error remain accessible in the error tree.

Closes #1051 