### PR TITLE
fix: add panic recovery

### DIFF
--- a/main.go
+++ b/main.go
@@ -3856,6 +3856,11 @@ func main() {
 		}
 		if !disableNotifications {
 			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("panic in macOS sync goroutine: %v", r)
+					}
+				}()
 				_ = config.SyncMacOSContacts()
 				_ = theme.SyncWithMacOS()
 			}()


### PR DESCRIPTION
## What?

Added panic recovery and proper error logging to the macOS sync goroutine in `main.go`.

## Why?

The goroutine running `config.SyncMacOSContacts()` and `theme.SyncWithMacOS()` had no panic recovery. If either function panicked, it would silently crash the entire TUI process.

Closes #981 