### PR TITLE
fix(tui): add cyclic navigation

### DIFF
--- a/tui/choice.go
+++ b/tui/choice.go
@@ -77,13 +77,9 @@ func (m Choice) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		kb := config.Keybinds
 		switch msg.String() {
 		case "up", kb.Global.NavUp:
-			if m.cursor > 0 {
-				m.cursor--
-			}
+			m.cursor = (m.cursor - 1 + len(m.choices)) % len(m.choices)
 		case "down", kb.Global.NavDown:
-			if m.cursor < len(m.choices)-1 {
-				m.cursor++
-			}
+			m.cursor = (m.cursor + 1) % len(m.choices)
 		case "enter":
 			// Use cursor index instead of string comparison
 			idx := m.cursor


### PR DESCRIPTION
## What?

- Updated the `Update` function in `tui/choice.go` to modify the cursor navigation logic.
- Implemented wrap-around (cyclic) navigation for the `up` and `down` keybindings, allowing the cursor to loop seamlessly through the choices.

## Why?

- Currently, menu selection stops when reaching the first or last item, requiring users to reverse direction to navigate the list.
- Implementing wrap-around navigation solves this problem. Now, moving upward from the first item selects the last item, and moving downward from the last item selects the first item.
- This provides a smoother, more natural navigation experience and reduces unnecessary input keystrokes.
- closes #1215 