### PR TITLE
fix(tui): aggregate folder fetch errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -515,6 +515,11 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.folderInbox == nil {
 			return m, nil
 		}
+		// Surface per-account fetch failures so a broken account is visible
+		// in the logs rather than silently producing an empty inbox.
+		for accID, err := range msg.AccountErrors {
+			log.Printf("folder %s: account %s fetch failed: %v", msg.FolderName, accID, err)
+		}
 		// Call plugin hooks for received emails
 		if m.plugins != nil {
 			for _, email := range msg.Emails {
@@ -2165,7 +2170,7 @@ func fetchFoldersCmd(cfg *config.Config) tea.Cmd {
 func fetchFolderEmailsCmd(cfg *config.Config, folderName string) tea.Cmd {
 	return func() tea.Msg {
 		emailsByAccount := make(map[string][]fetcher.Email)
-		accountErrors := make(map[string]error)
+		var accountErrors map[string]error
 		var mu sync.Mutex
 		var wg sync.WaitGroup
 
@@ -2176,6 +2181,9 @@ func fetchFolderEmailsCmd(cfg *config.Config, folderName string) tea.Cmd {
 				emails, err := fetcher.FetchFolderEmails(&acc, folderName, initialEmailLimit, 0)
 				if err != nil {
 					mu.Lock()
+					if accountErrors == nil {
+						accountErrors = make(map[string]error)
+					}
 					accountErrors[acc.ID] = err
 					mu.Unlock()
 					return

--- a/main.go
+++ b/main.go
@@ -2165,6 +2165,7 @@ func fetchFoldersCmd(cfg *config.Config) tea.Cmd {
 func fetchFolderEmailsCmd(cfg *config.Config, folderName string) tea.Cmd {
 	return func() tea.Msg {
 		emailsByAccount := make(map[string][]fetcher.Email)
+		accountErrors := make(map[string]error)
 		var mu sync.Mutex
 		var wg sync.WaitGroup
 
@@ -2174,7 +2175,9 @@ func fetchFolderEmailsCmd(cfg *config.Config, folderName string) tea.Cmd {
 				defer wg.Done()
 				emails, err := fetcher.FetchFolderEmails(&acc, folderName, initialEmailLimit, 0)
 				if err != nil {
-					// Folder may not exist for this account — silently skip
+					mu.Lock()
+					accountErrors[acc.ID] = err
+					mu.Unlock()
 					return
 				}
 				mu.Lock()
@@ -2200,8 +2203,9 @@ func fetchFolderEmailsCmd(cfg *config.Config, folderName string) tea.Cmd {
 		}
 
 		return tui.FolderEmailsFetchedMsg{
-			Emails:     allEmails,
-			FolderName: folderName,
+			Emails:        allEmails,
+			FolderName:    folderName,
+			AccountErrors: accountErrors,
 		}
 	}
 }

--- a/tui/messages.go
+++ b/tui/messages.go
@@ -388,6 +388,8 @@ type FolderEmailsFetchedMsg struct {
 	Emails     []fetcher.Email
 	AccountID  string
 	FolderName string
+	// AccountErrors maps account ID to fetch error for accounts that failed.
+	AccountErrors map[string]error
 }
 
 // FolderEmailsAppendedMsg signals that more emails from a folder have been fetched (pagination).


### PR DESCRIPTION


## What?

- **`tui/messages.go`** -- `FolderEmailsFetchedMsg` gains an `AccountErrors map[string]error` field. Existing fields untouched, so this is additive for all current consumers.
- **`main.go`** -- `fetchFolderEmailsCmd` now collects per-account errors into an `accountErrors` map under the existing mutex (replacing the silent-skip return) and populates `AccountErrors` on the returned message.

## Why?

`fetchFolderEmailsCmd` (main.go) silently dropped `fetcher.FetchFolderEmails` errors per account by `return`-ing from the goroutine. A broken account showed no mail, and the UI had no signal beyond an empty list.

Closes #1126
