### PR TITLE
fix(tui): stop attachment nav scroll

### DIFF
--- a/tui/email_view.go
+++ b/tui/email_view.go
@@ -209,10 +209,12 @@ func (m *EmailView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.attachmentCursor > 0 {
 					m.attachmentCursor--
 				}
+				return m, nil
 			case "down", kb.Global.NavDown:
 				if m.attachmentCursor < len(m.email.Attachments)-1 {
 					m.attachmentCursor++
 				}
+				return m, nil
 			case "enter":
 				if len(m.email.Attachments) > 0 {
 					selected := m.email.Attachments[m.attachmentCursor]

--- a/tui/email_view_test.go
+++ b/tui/email_view_test.go
@@ -94,6 +94,26 @@ func TestEmailViewUpdate(t *testing.T) {
 		}
 	})
 
+	t.Run("Attachment navigation does not scroll body", func(t *testing.T) {
+		emailView := NewEmailView(emailWithAttachments, 0, 80, 24, MailboxInbox, false)
+		emailView.viewport.SetHeight(2)
+		emailView.viewport.SetContent("line 1\nline 2\nline 3\nline 4\nline 5\n")
+		emailView.viewport.SetYOffset(1)
+
+		model, _ := emailView.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+		emailView = model.(*EmailView)
+		if !emailView.focusOnAttachments {
+			t.Fatal("focusOnAttachments should be true after tabbing")
+		}
+
+		before := emailView.viewport.YOffset()
+		model, _ = emailView.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+		emailView = model.(*EmailView)
+		if got := emailView.viewport.YOffset(); got != before {
+			t.Fatalf("attachment navigation should not scroll the email body, got offset %d want %d", got, before)
+		}
+	})
+
 	t.Run("Download attachment", func(t *testing.T) {
 		emailView := NewEmailView(emailWithAttachments, 0, 80, 24, MailboxInbox, false)
 		// Focus on attachments


### PR DESCRIPTION
## What?

Prevents email body scrolling when navigating attachments in the email view.

## Why?

When attachment focus is active, up/down should only move the attachment selection. Previously, those key events also reached the email body viewport, causing the message content to scroll at the same time.