### PR TITLE
fix: mailbox channel send non-blocking

### DIFF
--- a/fetcher/idle.go
+++ b/fetcher/idle.go
@@ -158,8 +158,17 @@ func (a *accountIdle) idleOnce() error {
 	mailboxUpdates := make(chan uint32, 32)
 	c, err := connectWithHandler(a.account, &imapclient.UnilateralDataHandler{
 		Mailbox: func(data *imapclient.UnilateralDataMailbox) {
-			if data.NumMessages != nil {
-				mailboxUpdates <- *data.NumMessages
+			if data.NumMessages == nil {
+				return
+			}
+			// Non-blocking send: the callback runs on the IMAP socket-reader
+			// goroutine, so a synchronous send would stall the socket if the
+			// channel is full. The consumer only acts on the latest count
+			// (see prevExists tracking below), so dropping a stale update is
+			// safe — the next update will deliver the current count.
+			select {
+			case mailboxUpdates <- *data.NumMessages:
+			default:
 			}
 		},
 	})


### PR DESCRIPTION
## What?

`fetcher/idle.go` -- the `Mailbox` callback in `idleOnce` now uses a non-blocking send on the `mailboxUpdates` channel via `select { case mailboxUpdates <- *data.NumMessages: default: }`. The early-return for `data.NumMessages == nil` is hoisted to keep the select body small.

Closes #1124

## Why?

The callback runs on the IMAP socket-reader goroutine. The prior synchronous send blocks the callback whenever the 32-buffered channel is full, which stalls the socket reader itself. If the consuming select happens to be blocked (the stop-channel close race the issue describes), IDLE quietly hangs until the connection times out.

`mailboxUpdates` is a status-only channel: the consumer at line 191 only cares whether the latest count exceeds `prevExists`. Any value older than the most recent is already obsolete, so dropping a stale update on a full channel is harmless - the next callback fires with the current count and delivers it. The synchronous send traded nothing for the guaranteed deadlock in the failure mode the issue describes; the non-blocking send keeps the socket reader alive at the cost of a stale buffered value that would have been overwritten anyway.