### PR TITLE
feat: nix support + new site URL

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -159,7 +159,7 @@ jobs:
           cat > /tmp/matcha-nightly.rb << EOF
           class MatchaNightly < Formula
             desc "A beautiful and functional email client for your terminal (nightly)"
-            homepage "https://matcha.floatpane.com"
+            homepage "https://matcha.email"
             version "$VERSION"
 
             on_macos do
@@ -196,10 +196,100 @@ jobs:
           git clone "https://x-access-token:${GH_TOKEN}@github.com/floatpane/homebrew-matcha.git" /tmp/homebrew-matcha
           cp /tmp/matcha-nightly.rb /tmp/homebrew-matcha/matcha-nightly.rb
           cd /tmp/homebrew-matcha
-          git config user.name "goreleaserbot"
-          git config user.email "bot@goreleaser.com"
+          git config user.name "Floatpane Bot"
+          git config user.email "us@floatpane.com"
           git add matcha-nightly.rb
           git diff --cached --quiet || (git commit -m "Update matcha-nightly to $VERSION" && git push)
+
+      - name: Update Nix flake tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          VERSION="nightly-$(git rev-parse --short HEAD)"
+          DARWIN_AMD64_SHA=$(shasum -a 256 dist/matcha_nightly_darwin_amd64.tar.gz | cut -d ' ' -f 1)
+          DARWIN_ARM64_SHA=$(shasum -a 256 dist/matcha_nightly_darwin_arm64.tar.gz | cut -d ' ' -f 1)
+          LINUX_AMD64_SHA=$(shasum -a 256 dist/matcha_nightly_linux_amd64.tar.gz | cut -d ' ' -f 1)
+          LINUX_ARM64_SHA=$(shasum -a 256 dist/matcha_nightly_linux_arm64.tar.gz | cut -d ' ' -f 1)
+          BASE_URL="https://github.com/floatpane/matcha/releases/download/nightlyv0"
+
+          # Convert hex sha256 to nix SRI base64 form
+          to_sri() { printf 'sha256-%s' "$(printf '%s' "$1" | xxd -r -p | base64)"; }
+          DARWIN_AMD64_SRI=$(to_sri "$DARWIN_AMD64_SHA")
+          DARWIN_ARM64_SRI=$(to_sri "$DARWIN_ARM64_SHA")
+          LINUX_AMD64_SRI=$(to_sri "$LINUX_AMD64_SHA")
+          LINUX_ARM64_SRI=$(to_sri "$LINUX_ARM64_SHA")
+
+          mkdir -p /tmp/nix-pkg
+          cat > /tmp/nix-pkg/default.nix << EOF
+          { stdenvNoCC, fetchurl, lib }:
+          let
+            sources = {
+              x86_64-darwin = {
+                url = "$BASE_URL/matcha_nightly_darwin_amd64.tar.gz";
+                hash = "$DARWIN_AMD64_SRI";
+              };
+              aarch64-darwin = {
+                url = "$BASE_URL/matcha_nightly_darwin_arm64.tar.gz";
+                hash = "$DARWIN_ARM64_SRI";
+              };
+              x86_64-linux = {
+                url = "$BASE_URL/matcha_nightly_linux_amd64.tar.gz";
+                hash = "$LINUX_AMD64_SRI";
+              };
+              aarch64-linux = {
+                url = "$BASE_URL/matcha_nightly_linux_arm64.tar.gz";
+                hash = "$LINUX_ARM64_SRI";
+              };
+            };
+            src = sources.\${stdenvNoCC.hostPlatform.system}
+              or (throw "matcha-nightly: unsupported system \${stdenvNoCC.hostPlatform.system}");
+          in
+          stdenvNoCC.mkDerivation {
+            pname = "matcha-nightly";
+            version = "$VERSION";
+            src = fetchurl src;
+            sourceRoot = ".";
+            installPhase = ''
+              runHook preInstall
+              install -Dm755 matcha \$out/bin/matcha
+              runHook postInstall
+            '';
+            meta = {
+              description = "Beautiful and functional email client for the terminal (nightly)";
+              homepage = "https://matcha.email";
+              license = lib.licenses.mit;
+              mainProgram = "matcha";
+              platforms = builtins.attrNames sources;
+            };
+          }
+          EOF
+
+          cat > /tmp/nix-pkg/flake.nix << 'EOF'
+          {
+            description = "matcha email client — nightly";
+            inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+            outputs = { self, nixpkgs }:
+              let
+                systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+                forAll = nixpkgs.lib.genAttrs systems;
+              in {
+                packages = forAll (system: {
+                  default = nixpkgs.legacyPackages.${system}.callPackage ./default.nix { };
+                });
+              };
+          }
+          EOF
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/floatpane/nix-matcha.git" /tmp/nix-matcha
+          cd /tmp/nix-matcha
+          git checkout nightly 2>/dev/null || git checkout -b nightly
+          mkdir -p nightly
+          cp /tmp/nix-pkg/default.nix nightly/default.nix
+          cp /tmp/nix-pkg/flake.nix nightly/flake.nix
+          git config user.name "Floatpane Bot"
+          git config user.email "us@floatpane.com"
+          git add nightly/default.nix nightly/flake.nix
+          git diff --cached --quiet || (git commit -m "matcha-nightly: bump to $VERSION" && git push -u origin nightly)
 
   snapcraft:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/nixpkgs-bump.yml
+++ b/.github/workflows/nixpkgs-bump.yml
@@ -1,0 +1,174 @@
+name: Nixpkgs Bump PR
+
+# Triggers on stable release publish. Opens PR against NixOS/nixpkgs
+# bumping pkgs/by-name/ma/matcha/package.nix to the new version.
+# Requires:
+#   - Fork floatpane/nixpkgs to exist
+#   - NIXPKGS_BUMP_TOKEN secret: PAT with `repo` scope on floatpane/nixpkgs
+#     and permission to open PRs against NixOS/nixpkgs
+#   - Initial matcha package already merged into nixpkgs (this workflow updates, not inits)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to bump to (without v prefix)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
+          fi
+          # Skip nightly / preview tags
+          if [[ "$VERSION" == nightly* || "$VERSION" == preview* ]]; then
+            echo "Skipping non-stable release: $VERSION"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Install Nix
+        if: steps.ver.outputs.skip != 'true'
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Checkout nixpkgs fork
+        if: steps.ver.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: floatpane/nixpkgs
+          token: ${{ secrets.NIXPKGS_BUMP_TOKEN }}
+          path: nixpkgs
+          fetch-depth: 0
+
+      - name: Sync fork with upstream master
+        if: steps.ver.outputs.skip != 'true'
+        working-directory: nixpkgs
+        run: |
+          git config user.name "Floatpane Bot"
+          git config user.email "us@floatpane.com"
+          git remote add upstream https://github.com/NixOS/nixpkgs.git
+          git fetch upstream master
+          git checkout master
+          git reset --hard upstream/master
+          git push origin master --force-with-lease
+
+      - name: Create bump branch
+        if: steps.ver.outputs.skip != 'true'
+        working-directory: nixpkgs
+        run: |
+          BRANCH="matcha-${{ steps.ver.outputs.version }}"
+          git checkout -b "$BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Get current version
+        if: steps.ver.outputs.skip != 'true'
+        id: current
+        working-directory: nixpkgs
+        run: |
+          PKG=pkgs/by-name/ma/matcha/package.nix
+          OLD=$(grep -E '^\s*version\s*=\s*"' "$PKG" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "old=$OLD" >> $GITHUB_OUTPUT
+
+      - name: Bump version and reset hashes
+        if: steps.ver.outputs.skip != 'true'
+        working-directory: nixpkgs
+        run: |
+          PKG=pkgs/by-name/ma/matcha/package.nix
+          NEW="${{ steps.ver.outputs.version }}"
+          # Replace version line
+          sed -i -E "s/(version\s*=\s*\")[^\"]+(\")/\1$NEW\2/" "$PKG"
+          # Reset src hash + vendorHash to fakeHash so nix build prints real ones
+          sed -i -E 's|hash = "sha256-[A-Za-z0-9+/=]+"|hash = lib.fakeHash|' "$PKG"
+          sed -i -E 's|vendorHash = "sha256-[A-Za-z0-9+/=]+"|vendorHash = lib.fakeHash|' "$PKG"
+
+      - name: Build to extract src hash
+        if: steps.ver.outputs.skip != 'true'
+        id: src_hash
+        working-directory: nixpkgs
+        run: |
+          set +e
+          OUT=$(nix-build -A matcha --no-out-link 2>&1)
+          RC=$?
+          echo "$OUT"
+          HASH=$(echo "$OUT" | grep -A1 "got:" | tail -1 | tr -d ' ')
+          if [ -z "$HASH" ]; then
+            echo "Failed to extract src hash"; exit 1
+          fi
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+          sed -i -E "s|hash = lib.fakeHash|hash = \"$HASH\"|" pkgs/by-name/ma/matcha/package.nix
+
+      - name: Build to extract vendorHash
+        if: steps.ver.outputs.skip != 'true'
+        working-directory: nixpkgs
+        run: |
+          set +e
+          OUT=$(nix-build -A matcha --no-out-link 2>&1)
+          RC=$?
+          echo "$OUT"
+          HASH=$(echo "$OUT" | grep -A1 "got:" | tail -1 | tr -d ' ')
+          if [ -z "$HASH" ]; then
+            echo "Failed to extract vendorHash"; exit 1
+          fi
+          sed -i -E "s|vendorHash = lib.fakeHash|vendorHash = \"$HASH\"|" pkgs/by-name/ma/matcha/package.nix
+
+      - name: Final build (sanity check)
+        if: steps.ver.outputs.skip != 'true'
+        working-directory: nixpkgs
+        run: nix-build -A matcha --no-out-link
+
+      - name: Commit and push
+        if: steps.ver.outputs.skip != 'true'
+        working-directory: nixpkgs
+        run: |
+          git add pkgs/by-name/ma/matcha/package.nix
+          git commit -m "matcha: ${{ steps.current.outputs.old }} -> ${{ steps.ver.outputs.version }}"
+          git push -u origin "$BRANCH" --force-with-lease
+
+      - name: Open PR against NixOS/nixpkgs
+        if: steps.ver.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.NIXPKGS_BUMP_TOKEN }}
+        working-directory: nixpkgs
+        run: |
+          BODY=$(cat <<EOF
+          ## Description
+
+          Automated version bump for \`matcha\` email client.
+
+          - Old: ${{ steps.current.outputs.old }}
+          - New: ${{ steps.ver.outputs.version }}
+          - Upstream release: https://github.com/floatpane/matcha/releases/tag/v${{ steps.ver.outputs.version }}
+
+          ## Things done
+
+          - Built on \`x86_64-linux\` via GitHub Actions
+          - Hashes regenerated from upstream tarball
+          - No package metadata changes beyond version + hashes
+
+          cc maintainer for review.
+          EOF
+          )
+          gh pr create \
+            --repo NixOS/nixpkgs \
+            --base master \
+            --head "floatpane:$BRANCH" \
+            --title "matcha: ${{ steps.current.outputs.old }} -> ${{ steps.ver.outputs.version }}" \
+            --body "$BODY"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -100,9 +100,31 @@ release:
   # Add a footer to the release notes featuring full changelog.
   footer: |
     ---
-    This version is also available on **[Snapcraft](https://snapcraft.io/matcha)**, **Homebrew**, **[Flatpak](https://matcha.floatpane.com/matcha.flatpakref)**!
+    This version is also available on **[Snapcraft](https://snapcraft.io/matcha)**, **Homebrew**, **[Flatpak](https://matcha.email/matcha.flatpakref)**!
 
-    View the [installation instructions](https://docs.matcha.floatpane.com/installation) for more details.
+    View the [installation instructions](https://docs.matcha.email/installation) for more details.
+
+# 'nix' configures the Nix flake publication.
+# Generates a default.nix per release fetching prebuilt tarballs,
+# pushes to floatpane/nix-matcha. Users install with:
+#   nix profile install github:floatpane/nix-matcha
+nix:
+  - name: matcha
+    repository:
+      owner: floatpane
+      name: nix-matcha
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: Floatpane Bot
+      email: us@floatpane.com
+    commit_msg_template: "matcha: bump to {{ .Tag }}"
+    homepage: "https://matcha.email"
+    description: "Beautiful and functional email client for the terminal"
+    license: "mit"
+    install: |
+      mkdir -p $out/bin
+      cp -vr ./matcha $out/bin/matcha
 
 # 'brews' configures the Homebrew tap integration.
 brews:
@@ -119,13 +141,13 @@ brews:
 
     # The commit author for the tap update.
     commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
+      name: Floatpane Bot
+      email: us@floatpane.com
 
     # A description for your formula.
     description: "A beautiful and functional email client for your terminal."
     # The homepage URL for your formula.
-    homepage: "https://matcha.floatpane.com"
+    homepage: "https://matcha.email"
 
     # The dependencies for your formula.
     # Since it's a pre-compiled binary, there are no runtime dependencies.
@@ -148,7 +170,7 @@ winget:
     package_identifier: floatpane.matcha
     # WinGet publisher metadata.
     publisher: floatpane
-    publisher_url: "https://matcha.floatpane.com"
+    publisher_url: "https://matcha.email"
     publisher_support_url: "https://github.com/floatpane/matcha/issues"
 
     # Package metadata.
@@ -156,7 +178,7 @@ winget:
     description: |
       A beautiful and functional email client for your terminal, built with Go and the charming Bubble Tea TUI library.
       Never leave your command line to check your inbox or send an email again!
-    homepage: "https://matcha.floatpane.com"
+    homepage: "https://matcha.email"
     license: MIT
     tags:
       - email

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ### Plugin Marketplace
 
-Matcha has a built-in plugin system with 35+ community plugins. Browse and install them from the terminal or the [online marketplace](https://docs.matcha.floatpane.com/marketplace).
+Matcha has a built-in plugin system with 35+ community plugins. Browse and install them from the terminal or the [online marketplace](https://docs.matcha.email/marketplace).
 
 ```bash
 matcha marketplace                # browse plugins in the TUI
@@ -36,7 +36,7 @@ matcha install <url_or_file>      # install a plugin
 matcha config <plugin_name>       # configure an installed plugin
 ```
 
-Anyone can submit their own plugin — just add an entry to `plugins/registry.json` and open a PR. [Learn more](https://docs.matcha.floatpane.com/Features/Plugins#submit-your-plugin)
+Anyone can submit their own plugin — just add an entry to `plugins/registry.json` and open a PR. [Learn more](https://docs.matcha.email/Features/Plugins#submit-your-plugin)
 
 ### AI Integration
 
@@ -46,15 +46,15 @@ Anyone can submit their own plugin — just add an entry to `plugins/registry.js
 matcha send --to alice@example.com --subject "Hello" --body "Sent by my AI agent"
 ```
 
-[Learn more](https://docs.matcha.floatpane.com/Features/AI_AGENTS)
+[Learn more](https://docs.matcha.email/Features/AI_AGENTS)
 
 **AI Rewrite Plugin:** Matcha includes an AI rewrite plugin that allows you to rewrite your email drafts using OpenAI, Ollama, Gemini, or Claude.
 
-[Setup Guide](https://docs.matcha.floatpane.com/setup-guides/ai-rewrite)
+[Setup Guide](https://docs.matcha.email/setup-guides/ai-rewrite)
 
 ## Documentation
 
-Matcha Documention is available on [our website](https://docs.matcha.floatpane.com)
+Matcha Documention is available on [our website](https://docs.matcha.email)
 
 ## Star History
 

--- a/docs/docs/Features/CLI.md
+++ b/docs/docs/Features/CLI.md
@@ -98,7 +98,7 @@ matcha marketplace
 
 Use `j/k` or arrow keys to navigate, `Enter` to install a plugin, and `q` to quit. Installed plugins are marked with an `[installed]` badge.
 
-You can also access the marketplace from Matcha's main menu, or browse the [online marketplace](https://docs.matcha.floatpane.com/marketplace).
+You can also access the marketplace from Matcha's main menu, or browse the [online marketplace](https://docs.matcha.email/marketplace).
 
 ## matcha install
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -68,7 +68,7 @@ sudo snap install matcha
 You can install Matcha via Flatpak using the following command:
 
 ```bash
-flatpak install https://matcha.floatpane.com/matcha.flatpakref
+flatpak install https://matcha.email/matcha.flatpakref
 ```
 
 ### AUR (Arch Linux) (unofficial)

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
     "A modern, beautiful, and feature-rich email client for the terminal.",
   favicon: "img/favicon.ico",
 
-  url: "https://docs.matcha.floatpane.com",
+  url: "https://docs.matcha.email",
   baseUrl: "/",
 
   organizationName: "floatpane",

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -606,4 +606,4 @@ Always keep variables unchanged:
 
 ---
 
-**For more details on using translations in code, see:** [Documentation](https://docs.matcha.floatpane.com/localization).
+**For more details on using translations in code, see:** [Documentation](https://docs.matcha.email/localization).

--- a/nix/maintainer-entry.nix
+++ b/nix/maintainer-entry.nix
@@ -1,0 +1,13 @@
+  # Paste this block into nixpkgs/maintainers/maintainer-list.nix
+  # at the correct alphabetical position (between `andresilva` and `andrew-d`
+  # or wherever `andr*` lands when you check the file).
+  #
+  # The key (`andrinoff`) must match `meta.maintainers = [ andrinoff ];`
+  # in pkgs/by-name/ma/matcha/package.nix.
+
+  andrinoff = {
+    name = "Drew Smirnoff";
+    email = "me@andrinoff.com";
+    github = "andrinoff";
+    githubId = 175145001;
+  };

--- a/nix/nixpkgs-package.nix
+++ b/nix/nixpkgs-package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  pcsclite,
+  stdenv,
+  apple-sdk_15,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "matcha";
+  version = "0.37.0";
+
+  src = fetchFromGitHub {
+    owner = "floatpane";
+    repo = "matcha";
+    tag = "v${finalAttrs.version}";
+    hash = lib.fakeHash;
+  };
+
+  vendorHash = lib.fakeHash;
+  proxyVendor = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+  ];
+
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [ pcsclite ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ];
+
+  env.CGO_ENABLED = 1;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.date=1970-01-01T00:00:00Z"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Beautiful and functional email client for the terminal";
+    homepage = "https://matcha.email";
+    changelog = "https://github.com/floatpane/matcha/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "matcha";
+    maintainers = with lib.maintainers; [ andrinoff ];
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+  };
+})

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -50,7 +50,7 @@ Anyone can add their plugin to the marketplace by submitting a PR to this reposi
 
 ### Steps
 
-1. **Write your plugin** as a `.lua` file following the [Plugin API docs](https://docs.matcha.floatpane.com/Features/Plugins).
+1. **Write your plugin** as a `.lua` file following the [Plugin API docs](https://docs.matcha.email/Features/Plugins).
 
 2. **Add an entry to `registry.json`** in this directory:
 
@@ -90,4 +90,4 @@ Anyone can add their plugin to the marketplace by submitting a PR to this reposi
 
 ## Browsing Online
 
-Visit the [Plugin Marketplace](https://docs.matcha.floatpane.com/marketplace) on the Matcha documentation site to browse all available plugins with one-line install commands.
+Visit the [Plugin Marketplace](https://docs.matcha.email/marketplace) on the Matcha documentation site to browse all available plugins with one-line install commands.

--- a/public/components/site.jsx
+++ b/public/components/site.jsx
@@ -63,7 +63,7 @@ function TopNav() {
         <a href="#features">Features</a>
         <a href="#keys">Keybinds</a>
         <a href="#install">Install</a>
-        <a href="https://docs.matcha.floatpane.com">Docs ↗</a>
+        <a href="https://docs.matcha.email">Docs ↗</a>
         <a href="https://github.com/floatpane/matcha" className="nav-github">
           <span>GitHub</span>
           {stars && <span className="nav-star">★ {stars}</span>}
@@ -103,7 +103,7 @@ function Hero({ datasetKey, setDatasetKey }) {
             <span>Install</span>
             <span className="btn-k">↵</span>
           </a>
-          <a href="https://docs.matcha.floatpane.com" className="btn btn-ghost">
+          <a href="https://docs.matcha.email" className="btn btn-ghost">
             <span>Read the docs</span>
             <span className="btn-k">→</span>
           </a>
@@ -336,11 +336,8 @@ function Keybinds() {
         </div>
         <p className="section-head-r">
           Every binding is documented at{" "}
-          <a
-            href="https://docs.matcha.floatpane.com"
-            className="underline-link"
-          >
-            docs.matcha.floatpane.com
+          <a href="https://docs.matcha.email" className="underline-link">
+            docs.matcha.email
           </a>
           . Muscle-memory for vimmers, learnable for everyone else.
         </p>
@@ -377,7 +374,7 @@ const INSTALL_TABS = {
   snap: { plat: "Ubuntu · Linux", cmd: "$ sudo snap install matcha\n$ matcha" },
   flatpak: {
     plat: "Linux",
-    cmd: "$ flatpak install https://matcha.floatpane.com/matcha.flatpakref\n$ matcha",
+    cmd: "$ flatpak install https://matcha.email/matcha.flatpakref\n$ matcha",
   },
   aur: { plat: "Arch Linux", cmd: "$ yay -S matcha-client-bin\n$ matcha" },
   nix: {
@@ -482,10 +479,7 @@ function CTA() {
           <a href="#install" className="btn btn-primary btn-lg">
             make your emails secure
           </a>
-          <a
-            href="https://docs.matcha.floatpane.com"
-            className="btn btn-ghost btn-lg"
-          >
+          <a href="https://docs.matcha.email" className="btn btn-ghost btn-lg">
             read the docs →
           </a>
         </div>
@@ -516,9 +510,9 @@ function Footer() {
           </div>
           <div>
             <div className="footer-h">resources</div>
-            <a href="https://docs.matcha.floatpane.com">docs</a>
-            <a href="https://docs.matcha.floatpane.com/Configuration">config</a>
-            <a href="https://docs.matcha.floatpane.com/Features/CLI">cli</a>
+            <a href="https://docs.matcha.email">docs</a>
+            <a href="https://docs.matcha.email/Configuration">config</a>
+            <a href="https://docs.matcha.email/Features/CLI">cli</a>
             <a href="https://github.com/floatpane/matcha/blob/master/SECURITY.md">
               security
             </a>

--- a/public/matcha.flatpakref
+++ b/public/matcha.flatpakref
@@ -3,5 +3,5 @@ Name=com.floatpane.matcha
 Branch=master
 Title=Matcha
 IsRuntime=False
-Url=https://matcha.floatpane.com/repo/
+Url=https://matcha.email/repo/
 SuggestRemoteName=matcha


### PR DESCRIPTION
## What?

- **Goreleaser nix publisher** (`goreleaser.yml`): on each stable release, goreleaser pushes a prebuilt `default.nix` to `floatpane/nix-matcha` (`main` branch). Users can install via `nix profile install github:floatpane/nix-matcha`.

- **Nightly nix tap** (`nightly.yml`): mirrors the existing brew tap step — after each nightly build, computes sha256s for all four platform tarballs, templates `default.nix` + `flake.nix`, pushes to `floatpane/nix-matcha` (`nightly` branch).

- **Nixpkgs bump workflow** (`nixpkgs-bump.yml`): on stable release publish, syncs `floatpane/nixpkgs` fork with upstream, bumps version + hashes in `pkgs/by-name/ma/matcha/package.nix`, builds to verify, opens a PR against `NixOS/nixpkgs`. Skips nightly/preview tags automatically.

- **Reference derivation** (`nix/nixpkgs-package.nix`): canonical `buildGoModule` derivation for the manual nixpkgs init PR and as ground truth for the bump workflow.

## Why?

Closes #1245 

NixOS/nixpkgs#518988 initial PR.