### PR TITLE
ci: label PRs by diff size

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -138,3 +138,20 @@
 - name: area/docs
   color: c2e0c6
   description: Docs site / README
+
+# --- Size ---
+- name: size/XS
+  color: "3cbf00"
+  description: "Diff: 0–10 lines"
+- name: size/S
+  color: "5d9801"
+  description: "Diff: 11–50 lines"
+- name: size/M
+  color: "eebb00"
+  description: "Diff: 51–200 lines"
+- name: size/L
+  color: "ee9900"
+  description: "Diff: 201–800 lines"
+- name: size/XL
+  color: "ee5500"
+  description: "Diff: 800+ lines"

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,21 @@
+name: PR Size Label
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
+          xs_max_size: 10
+          s_max_size: 50
+          m_max_size: 200
+          l_max_size: 800
+          fail_if_xl: false


### PR DESCRIPTION
## What?

adds diff size labeler for pull requests

## Why?

makes it easier to check prs for maintainers
