### PR TITLE
docs: Open Collective funding option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 custom: https://andrinoff.com/sponsor
+open_collective: matcha


### PR DESCRIPTION
## What?

Adds Opem Collective URL

## Why?

For sponsoring
