### PR TITLE
fix(fetcher): nil-safe charset lookup

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -30,7 +30,9 @@ import (
 	"github.com/emersion/go-pgpmail"
 	"github.com/floatpane/matcha/config"
 	"go.mozilla.org/pkcs7"
+	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/ianaindex"
+	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
 
@@ -228,13 +230,24 @@ func decodePart(reader io.Reader, header mail.PartHeader) (string, error) {
 }
 
 func decodeReaderWithCharset(reader io.Reader, charset string) ([]byte, error) {
-	encoding, err := ianaindex.IANA.Encoding(charset)
-	if err != nil || encoding == nil {
-		encoding, _ = ianaindex.IANA.Encoding("utf-8")
-	}
-
-	transformReader := transform.NewReader(reader, encoding.NewDecoder())
+	enc := lookupCharsetEncoding(charset)
+	transformReader := transform.NewReader(reader, enc.NewDecoder())
 	return ioutil.ReadAll(transformReader)
+}
+
+// lookupCharsetEncoding resolves an IANA charset name to an encoding,
+// falling back to UTF-8 when the name is unknown, unsupported, or maps
+// to a nil encoding (which ianaindex.IANA.Encoding can return for
+// recognized-but-unimplemented names). Always returns a non-nil
+// encoding so callers can safely chain .NewDecoder().
+func lookupCharsetEncoding(charset string) encoding.Encoding {
+	if enc, err := ianaindex.IANA.Encoding(charset); err == nil && enc != nil {
+		return enc
+	}
+	if enc, err := ianaindex.IANA.Encoding("utf-8"); err == nil && enc != nil {
+		return enc
+	}
+	return unicode.UTF8
 }
 
 func bestEffortCharset(contentType string) string {
@@ -256,11 +269,14 @@ func bestEffortCharset(contentType string) string {
 func decodeHeader(header string) string {
 	dec := new(mime.WordDecoder)
 	dec.CharsetReader = func(charset string, input io.Reader) (io.Reader, error) {
-		encoding, err := ianaindex.IANA.Encoding(charset)
+		enc, err := ianaindex.IANA.Encoding(charset)
 		if err != nil {
 			return nil, err
 		}
-		return transform.NewReader(input, encoding.NewDecoder()), nil
+		if enc == nil {
+			return nil, fmt.Errorf("fetcher: no encoding implementation for charset %q", charset)
+		}
+		return transform.NewReader(input, enc.NewDecoder()), nil
 	}
 	decoded, err := dec.DecodeHeader(header)
 	if err != nil {

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -235,11 +235,7 @@ func decodeReaderWithCharset(reader io.Reader, charset string) ([]byte, error) {
 	return ioutil.ReadAll(transformReader)
 }
 
-// lookupCharsetEncoding resolves an IANA charset name to an encoding,
-// falling back to UTF-8 when the name is unknown, unsupported, or maps
-// to a nil encoding (which ianaindex.IANA.Encoding can return for
-// recognized-but-unimplemented names). Always returns a non-nil
-// encoding so callers can safely chain .NewDecoder().
+// lookupCharsetEncoding resolves a charset name, falling back to UTF-8.
 func lookupCharsetEncoding(charset string) encoding.Encoding {
 	if enc, err := ianaindex.IANA.Encoding(charset); err == nil && enc != nil {
 		return enc

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -54,10 +54,6 @@ func TestDecodePartFallsBackToUTF8WhenMalformedContentTypeHasNoCharset(t *testin
 	}
 }
 
-// Regression: ianaindex.IANA.Encoding can return (nil, nil) for charset
-// names it recognizes but has no implementation for. The previous
-// decodeReaderWithCharset ignored that case and would nil-deref when
-// chaining .NewDecoder().
 func TestDecodeReaderWithCharsetSurvivesUnknownCharset(t *testing.T) {
 	decoded, err := decodeReaderWithCharset(strings.NewReader("hello"), "bogus-charset-name")
 	if err != nil {

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -54,6 +54,31 @@ func TestDecodePartFallsBackToUTF8WhenMalformedContentTypeHasNoCharset(t *testin
 	}
 }
 
+// Regression: ianaindex.IANA.Encoding can return (nil, nil) for charset
+// names it recognizes but has no implementation for. The previous
+// decodeReaderWithCharset ignored that case and would nil-deref when
+// chaining .NewDecoder().
+func TestDecodeReaderWithCharsetSurvivesUnknownCharset(t *testing.T) {
+	decoded, err := decodeReaderWithCharset(strings.NewReader("hello"), "bogus-charset-name")
+	if err != nil {
+		t.Fatalf("decodeReaderWithCharset() returned error: %v", err)
+	}
+	if string(decoded) != "hello" {
+		t.Fatalf("decodeReaderWithCharset() = %q, want %q", string(decoded), "hello")
+	}
+}
+
+func TestLookupCharsetEncodingAlwaysReturnsNonNil(t *testing.T) {
+	cases := []string{"", "utf-8", "iso-8859-1", "bogus-charset-name", "this/is/not/real"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			if enc := lookupCharsetEncoding(name); enc == nil {
+				t.Fatalf("lookupCharsetEncoding(%q) returned nil", name)
+			}
+		})
+	}
+}
+
 // TestFetchEmails is an integration test that requires a live IMAP server and valid credentials.
 // NOTE: This test will be skipped if it cannot load a configuration file,
 // making it safe to run in a CI environment without credentials.


### PR DESCRIPTION


## What?

`decodeReaderWithCharset` and `decodeHeader`'s `CharsetReader` in `fetcher/fetcher.go` could nil-deref because `ianaindex.IANA.Encoding` is allowed to return `(nil, nil)` for charset names it recognizes but has no implementation for. The previous code chained `.NewDecoder()` on that nil encoding.

Refactor: introduce `lookupCharsetEncoding` that always returns a non-nil `encoding.Encoding` by trying the requested charset, then `ianaindex`'s "utf-8", then `encoding/unicode.UTF8` as final guarantee. Use it from `decodeReaderWithCharset`. Guard the `decodeHeader` path explicitly so the nil-after-success case surfaces as a clean error.

## Why?

Fixes #896.

Without the guard, a real message with an unusual charset header can panic the fetcher. The fix is minimal, has no behavior change for the common path (a valid charset still resolves the same way), and is covered by two new tests:

- `TestDecodeReaderWithCharsetSurvivesUnknownCharset` (issue regression)
- `TestLookupCharsetEncodingAlwaysReturnsNonNil` (table-driven contract)

