### PR TITLE
fix(reply): use send-as envelope

### DIFF
--- a/sender/sender.go
+++ b/sender/sender.go
@@ -711,7 +711,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 	}
 
 	// Send Envelope
-	if err = c.Mail(account.Email); err != nil {
+	if err = c.Mail(account.GetSendAsEmail()); err != nil {
 		return nil, err
 	}
 	for _, r := range allRecipients {
@@ -916,7 +916,7 @@ func SendCalendarReply(account *config.Account, to []string, subject, plainBody 
 		}
 	}
 
-	if err = c.Mail(account.Email); err != nil {
+	if err = c.Mail(account.GetSendAsEmail()); err != nil {
 		return nil, err
 	}
 	for _, r := range to {

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -711,7 +711,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 	}
 
 	// Send Envelope
-	if err = c.Mail(account.GetFetchEmail()); err != nil {
+	if err = c.Mail(account.Email); err != nil {
 		return nil, err
 	}
 	for _, r := range allRecipients {
@@ -916,7 +916,7 @@ func SendCalendarReply(account *config.Account, to []string, subject, plainBody 
 		}
 	}
 
-	if err = c.Mail(account.GetFetchEmail()); err != nil {
+	if err = c.Mail(account.Email); err != nil {
 		return nil, err
 	}
 	for _, r := range to {


### PR DESCRIPTION
## What?

Updates the SMTP envelope sender for outgoing mail.

Matcha now uses `send_as_email` for `MAIL FROM` when it is configured. If it is not configured, it keeps the existing fallback behavior.

This applies to regular email sending and calendar replies.

## Why?

Closes #1274

Previously, `MAIL FROM` was based on `fetch_email`, with `account.email` as the fallback.

Now the order is:

```text
send_as_email -> fetch_email -> account.email
```

`fetch_email` is used to match incoming messages to an account. For outgoing mail, the configured Send-As address should be used first.
