### PR TITLE
test: check daemon unmarshal errors

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -99,7 +99,9 @@ func TestDaemon_PingHandler(t *testing.T) {
 		t.Fatal("expected Response")
 	}
 	var result daemonrpc.PingResult
-	json.Unmarshal(msg.Response.Result, &result)
+	if err := json.Unmarshal(msg.Response.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal ping result: %v", err)
+	}
 	if !result.Pong {
 		t.Error("expected pong=true")
 	}
@@ -115,7 +117,9 @@ func TestDaemon_StatusHandler(t *testing.T) {
 	msg := handlerTest(t, d, &daemonrpc.Request{ID: 1, Method: daemonrpc.MethodGetStatus})
 
 	var result daemonrpc.StatusResult
-	json.Unmarshal(msg.Response.Result, &result)
+	if err := json.Unmarshal(msg.Response.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal status result: %v", err)
+	}
 
 	if !result.Running {
 		t.Error("expected running=true")


### PR DESCRIPTION
## What?

- Check JSON unmarshal errors in daemon handler tests.
- Fail clearly when a response body cannot be decoded instead of ignoring the error.
- Keep the change limited to daemon tests.

## Why?

Ignoring `json.Unmarshal` errors can let malformed test responses pass into later assertions with less useful failures. This makes the daemon tests report decode problems at the source.

Fixes #718

## Validation

- go test ./daemon
- go test ./...