### PR TITLE
fix: add TLS session resumption

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -232,6 +232,13 @@ func (a *Account) GetSMTPServer() string {
 	}
 }
 
+func (a *Account) GetClientSessionCache() tls.ClientSessionCache {
+	if a.ClientSessionCache == nil {
+		a.ClientSessionCache = tls.NewLRUClientSessionCache(64)
+	}
+	return a.ClientSessionCache
+}
+
 // GetSMTPPort returns the SMTP port for the account.
 func (a *Account) GetSMTPPort() int {
 	switch a.ServiceProvider {
@@ -634,7 +641,6 @@ func LoadConfig() (*Config, error) {
 			POP3Server:         rawAcc.POP3Server,
 			POP3Port:           rawAcc.POP3Port,
 			CatchAll:           rawAcc.CatchAll,
-			ClientSessionCache: tls.NewLRUClientSessionCache(64),
 		}
 
 		// Validate PGPKeySource

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,11 @@ const (
 	DateFormatEU  = "DD/MM/YYYY HH:MM"
 )
 
+type SessionCache struct {
+	once  sync.Once
+	cache tls.ClientSessionCache
+}
+
 // Account stores the configuration for a single email account.
 type Account struct {
 	ID              string `json:"id"`
@@ -48,8 +53,7 @@ type Account struct {
 	// regardless of which address they were delivered to.
 	CatchAll bool `json:"catch_all,omitempty"`
 
-	ClientSessionCache tls.ClientSessionCache `json:"-"` // "-" prevents the ClientSessionCache from being saved to config.json
-	sessionCacheOnce   sync.Once              `json:"-"` // "-" prevents the sessionCacheOnce from being saved to config.json
+	SC *SessionCache `json:"-"` // "-" prevents the SessionCache from being saved to config.json
 
 	// Custom server settings (used when ServiceProvider is "custom")
 	IMAPServer string `json:"imap_server,omitempty"`
@@ -235,11 +239,11 @@ func (a *Account) GetSMTPServer() string {
 }
 
 func (a *Account) GetClientSessionCache() tls.ClientSessionCache {
-	a.sessionCacheOnce.Do(func() {
-		a.ClientSessionCache = tls.NewLRUClientSessionCache(64)
+	a.SC.once.Do(func() {
+		a.SC.cache = tls.NewLRUClientSessionCache(64)
 	})
 
-	return a.ClientSessionCache
+	return a.SC.cache
 }
 
 // GetSMTPPort returns the SMTP port for the account.
@@ -593,6 +597,7 @@ func LoadConfig() (*Config, error) {
 						Password:        legacyConfig.Password,
 						ServiceProvider: legacyConfig.ServiceProvider,
 						FetchEmail:      legacyConfig.Email,
+						SC:              &SessionCache{},
 					},
 				},
 			}
@@ -644,6 +649,7 @@ func LoadConfig() (*Config, error) {
 			POP3Server:         rawAcc.POP3Server,
 			POP3Port:           rawAcc.POP3Port,
 			CatchAll:           rawAcc.CatchAll,
+			SC:                 &SessionCache{},
 		}
 
 		// Validate PGPKeySource

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/zalando/go-keyring"
@@ -48,6 +49,7 @@ type Account struct {
 	CatchAll bool `json:"catch_all,omitempty"`
 
 	ClientSessionCache tls.ClientSessionCache `json:"-"` // "-" prevents the ClientSessionCache from being saved to config.json
+	sessionCacheOnce   sync.Once              `json:"-"` // "-" prevents the sessionCacheOnce from being saved to config.json
 
 	// Custom server settings (used when ServiceProvider is "custom")
 	IMAPServer string `json:"imap_server,omitempty"`
@@ -233,9 +235,10 @@ func (a *Account) GetSMTPServer() string {
 }
 
 func (a *Account) GetClientSessionCache() tls.ClientSessionCache {
-	if a.ClientSessionCache == nil {
+	a.sessionCacheOnce.Do(func() {
 		a.ClientSessionCache = tls.NewLRUClientSessionCache(64)
-	}
+	})
+
 	return a.ClientSessionCache
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -45,6 +46,8 @@ type Account struct {
 	// CatchAll skips per-address filtering so all inbox messages are shown,
 	// regardless of which address they were delivered to.
 	CatchAll bool `json:"catch_all,omitempty"`
+
+	ClientSessionCache tls.ClientSessionCache `json:"-"` // "-" prevents the ClientSessionCache from being saved to config.json
 
 	// Custom server settings (used when ServiceProvider is "custom")
 	IMAPServer string `json:"imap_server,omitempty"`
@@ -241,6 +244,12 @@ func (a *Account) GetSMTPPort() int {
 		return 587 // Default SMTP TLS port
 	default:
 		return 587
+	}
+}
+
+func (a *Account) EnsureSessionCache() {
+	if a.ClientSessionCache == nil {
+		a.ClientSessionCache = tls.NewLRUClientSessionCache(64)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -247,12 +247,6 @@ func (a *Account) GetSMTPPort() int {
 	}
 }
 
-func (a *Account) EnsureSessionCache() {
-	if a.ClientSessionCache == nil {
-		a.ClientSessionCache = tls.NewLRUClientSessionCache(64)
-	}
-}
-
 // GetFetchEmail returns the configured fetch identity, falling back to Email.
 func (a *Account) GetFetchEmail() string {
 	if a.FetchEmail != "" {
@@ -640,6 +634,7 @@ func LoadConfig() (*Config, error) {
 			POP3Server:         rawAcc.POP3Server,
 			POP3Port:           rawAcc.POP3Port,
 			CatchAll:           rawAcc.CatchAll,
+			ClientSessionCache: tls.NewLRUClientSessionCache(64),
 		}
 
 		// Validate PGPKeySource

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,6 +32,7 @@ func TestSaveAndLoadConfig(t *testing.T) {
 				Password:        "supersecret",
 				ServiceProvider: "gmail",
 				SendAsEmail:     "alias@example.com",
+				SC:              &SessionCache{},
 			},
 			{
 				ID:              "test-id-2",
@@ -44,6 +45,7 @@ func TestSaveAndLoadConfig(t *testing.T) {
 				SMTPServer:      "smtp.custom.com",
 				SMTPPort:        587,
 				CatchAll:        true,
+				SC:              &SessionCache{},
 			},
 		},
 	}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -376,7 +376,7 @@ func connectWithOptions(account *config.Account, extraOpts *imapclient.Options) 
 			ServerName:         imapServer,
 			InsecureSkipVerify: account.Insecure,
 			MinVersion:         tls.VersionTLS12,
-			ClientSessionCache: account.ClientSessionCache,
+			ClientSessionCache: account.GetClientSessionCache(),
 			VerifyConnection: func(cs tls.ConnectionState) error {
 				log.Printf("IMAP TLS connection resumed: %t", cs.DidResume)
 				return nil

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/emersion/go-message/mail"
 	"github.com/emersion/go-pgpmail"
 	"github.com/floatpane/matcha/config"
+	"github.com/floatpane/matcha/internal/loglevel"
 	"go.mozilla.org/pkcs7"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/ianaindex"
@@ -378,7 +379,7 @@ func connectWithOptions(account *config.Account, extraOpts *imapclient.Options) 
 			MinVersion:         tls.VersionTLS12,
 			ClientSessionCache: account.GetClientSessionCache(),
 			VerifyConnection: func(cs tls.ConnectionState) error {
-				log.Printf("IMAP TLS connection resumed: %t", cs.DidResume)
+				loglevel.Debugf("IMAP TLS connection resumed: %t", cs.DidResume)
 				return nil
 			},
 		},

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -371,11 +371,18 @@ func connectWithOptions(account *config.Account, extraOpts *imapclient.Options) 
 
 	addr := fmt.Sprintf("%s:%d", imapServer, imapPort)
 
+	account.EnsureSessionCache()
+
 	options := &imapclient.Options{
 		TLSConfig: &tls.Config{
 			ServerName:         imapServer,
 			InsecureSkipVerify: account.Insecure,
 			MinVersion:         tls.VersionTLS12,
+			ClientSessionCache: account.ClientSessionCache,
+			VerifyConnection: func(cs tls.ConnectionState) error {
+				log.Printf("SMTP connection resumed: %t", cs.DidResume)
+				return nil
+			},
 		},
 	}
 	if extraOpts != nil {

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -371,8 +371,6 @@ func connectWithOptions(account *config.Account, extraOpts *imapclient.Options) 
 
 	addr := fmt.Sprintf("%s:%d", imapServer, imapPort)
 
-	account.EnsureSessionCache()
-
 	options := &imapclient.Options{
 		TLSConfig: &tls.Config{
 			ServerName:         imapServer,
@@ -380,7 +378,7 @@ func connectWithOptions(account *config.Account, extraOpts *imapclient.Options) 
 			MinVersion:         tls.VersionTLS12,
 			ClientSessionCache: account.ClientSessionCache,
 			VerifyConnection: func(cs tls.ConnectionState) error {
-				log.Printf("SMTP connection resumed: %t", cs.DidResume)
+				log.Printf("IMAP TLS connection resumed: %t", cs.DidResume)
 				return nil
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -414,20 +415,21 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// New account: create one account per fetch email address
 			for _, fe := range fetchEmails {
 				account := config.Account{
-					ID:              uuid.New().String(),
-					Name:            msg.Name,
-					Email:           msg.Host,
-					Password:        msg.Password,
-					ServiceProvider: msg.Provider,
-					FetchEmail:      fe,
-					SendAsEmail:     msg.SendAsEmail,
-					CatchAll:        msg.CatchAll,
-					AuthMethod:      msg.AuthMethod,
-					Protocol:        msg.Protocol,
-					JMAPEndpoint:    msg.JMAPEndpoint,
-					POP3Server:      msg.POP3Server,
-					POP3Port:        msg.POP3Port,
-					MaildirPath:     msg.MaildirPath,
+					ID:                 uuid.New().String(),
+					Name:               msg.Name,
+					Email:              msg.Host,
+					Password:           msg.Password,
+					ServiceProvider:    msg.Provider,
+					FetchEmail:         fe,
+					SendAsEmail:        msg.SendAsEmail,
+					CatchAll:           msg.CatchAll,
+					AuthMethod:         msg.AuthMethod,
+					Protocol:           msg.Protocol,
+					JMAPEndpoint:       msg.JMAPEndpoint,
+					POP3Server:         msg.POP3Server,
+					POP3Port:           msg.POP3Port,
+					MaildirPath:        msg.MaildirPath,
+					ClientSessionCache: tls.NewLRUClientSessionCache(64),
 				}
 
 				if msg.Provider == "custom" || msg.Protocol == "pop3" {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -384,6 +383,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				POP3Server:      msg.POP3Server,
 				POP3Port:        msg.POP3Port,
 				MaildirPath:     msg.MaildirPath,
+				SC:              &config.SessionCache{},
 			}
 
 			if msg.Provider == "custom" || msg.Protocol == "pop3" {
@@ -415,21 +415,21 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// New account: create one account per fetch email address
 			for _, fe := range fetchEmails {
 				account := config.Account{
-					ID:                 uuid.New().String(),
-					Name:               msg.Name,
-					Email:              msg.Host,
-					Password:           msg.Password,
-					ServiceProvider:    msg.Provider,
-					FetchEmail:         fe,
-					SendAsEmail:        msg.SendAsEmail,
-					CatchAll:           msg.CatchAll,
-					AuthMethod:         msg.AuthMethod,
-					Protocol:           msg.Protocol,
-					JMAPEndpoint:       msg.JMAPEndpoint,
-					POP3Server:         msg.POP3Server,
-					POP3Port:           msg.POP3Port,
-					MaildirPath:        msg.MaildirPath,
-					ClientSessionCache: tls.NewLRUClientSessionCache(64),
+					ID:              uuid.New().String(),
+					Name:            msg.Name,
+					Email:           msg.Host,
+					Password:        msg.Password,
+					ServiceProvider: msg.Provider,
+					FetchEmail:      fe,
+					SendAsEmail:     msg.SendAsEmail,
+					CatchAll:        msg.CatchAll,
+					AuthMethod:      msg.AuthMethod,
+					Protocol:        msg.Protocol,
+					JMAPEndpoint:    msg.JMAPEndpoint,
+					POP3Server:      msg.POP3Server,
+					POP3Port:        msg.POP3Port,
+					MaildirPath:     msg.MaildirPath,
+					SC:              &config.SessionCache{},
 				}
 
 				if msg.Provider == "custom" || msg.Protocol == "pop3" {

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -657,15 +657,13 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 
 	addr := fmt.Sprintf("%s:%d", smtpServer, smtpPort)
 
-	account.EnsureSessionCache()
-
 	tlsConfig := &tls.Config{
 		ServerName:         smtpServer,
 		InsecureSkipVerify: account.Insecure,
 		MinVersion:         tls.VersionTLS12,
 		ClientSessionCache: account.ClientSessionCache,
 		VerifyConnection: func(cs tls.ConnectionState) error {
-			log.Printf("SMTP connection resumed: %t", cs.DidResume)
+			log.Printf("SMTP TLS connection resumed: %t", cs.DidResume)
 			return nil
 		},
 	}
@@ -879,15 +877,13 @@ func SendCalendarReply(account *config.Account, to []string, subject, plainBody 
 	// Send via SMTP
 	addr := fmt.Sprintf("%s:%d", smtpServer, smtpPort)
 
-	account.EnsureSessionCache()
-
 	tlsConfig := &tls.Config{
 		ServerName:         smtpServer,
 		InsecureSkipVerify: account.Insecure,
 		MinVersion:         tls.VersionTLS12,
 		ClientSessionCache: account.ClientSessionCache,
 		VerifyConnection: func(cs tls.ConnectionState) error {
-			log.Printf("SMTP connection resumed: %t", cs.DidResume)
+			log.Printf("SMTP TLS connection resumed: %t", cs.DidResume)
 			return nil
 		},
 	}

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"mime"
 	"mime/multipart"
 	"mime/quotedprintable"
@@ -26,6 +25,7 @@ import (
 	"github.com/emersion/go-pgpmail"
 	"github.com/floatpane/matcha/clib"
 	"github.com/floatpane/matcha/config"
+	"github.com/floatpane/matcha/internal/loglevel"
 	"github.com/floatpane/matcha/pgp"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
@@ -663,7 +663,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 		MinVersion:         tls.VersionTLS12,
 		ClientSessionCache: account.GetClientSessionCache(),
 		VerifyConnection: func(cs tls.ConnectionState) error {
-			log.Printf("SMTP TLS connection resumed: %t", cs.DidResume)
+			loglevel.Debugf("SMTP TLS connection resumed: %t", cs.DidResume)
 			return nil
 		},
 	}
@@ -883,7 +883,7 @@ func SendCalendarReply(account *config.Account, to []string, subject, plainBody 
 		MinVersion:         tls.VersionTLS12,
 		ClientSessionCache: account.GetClientSessionCache(),
 		VerifyConnection: func(cs tls.ConnectionState) error {
-			log.Printf("SMTP TLS connection resumed: %t", cs.DidResume)
+			loglevel.Debugf("SMTP TLS connection resumed: %t", cs.DidResume)
 			return nil
 		},
 	}

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"mime"
 	"mime/multipart"
 	"mime/quotedprintable"
@@ -656,10 +657,17 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 
 	addr := fmt.Sprintf("%s:%d", smtpServer, smtpPort)
 
+	account.EnsureSessionCache()
+
 	tlsConfig := &tls.Config{
 		ServerName:         smtpServer,
 		InsecureSkipVerify: account.Insecure,
 		MinVersion:         tls.VersionTLS12,
+		ClientSessionCache: account.ClientSessionCache,
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			log.Printf("SMTP connection resumed: %t", cs.DidResume)
+			return nil
+		},
 	}
 
 	var c *smtp.Client
@@ -870,10 +878,18 @@ func SendCalendarReply(account *config.Account, to []string, subject, plainBody 
 
 	// Send via SMTP
 	addr := fmt.Sprintf("%s:%d", smtpServer, smtpPort)
+
+	account.EnsureSessionCache()
+
 	tlsConfig := &tls.Config{
 		ServerName:         smtpServer,
 		InsecureSkipVerify: account.Insecure,
 		MinVersion:         tls.VersionTLS12,
+		ClientSessionCache: account.ClientSessionCache,
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			log.Printf("SMTP connection resumed: %t", cs.DidResume)
+			return nil
+		},
 	}
 
 	var c *smtp.Client

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -661,7 +661,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 		ServerName:         smtpServer,
 		InsecureSkipVerify: account.Insecure,
 		MinVersion:         tls.VersionTLS12,
-		ClientSessionCache: account.ClientSessionCache,
+		ClientSessionCache: account.GetClientSessionCache(),
 		VerifyConnection: func(cs tls.ConnectionState) error {
 			log.Printf("SMTP TLS connection resumed: %t", cs.DidResume)
 			return nil
@@ -881,7 +881,7 @@ func SendCalendarReply(account *config.Account, to []string, subject, plainBody 
 		ServerName:         smtpServer,
 		InsecureSkipVerify: account.Insecure,
 		MinVersion:         tls.VersionTLS12,
-		ClientSessionCache: account.ClientSessionCache,
+		ClientSessionCache: account.GetClientSessionCache(),
 		VerifyConnection: func(cs tls.ConnectionState) error {
 			log.Printf("SMTP TLS connection resumed: %t", cs.DidResume)
 			return nil


### PR DESCRIPTION
## What?

Configured `TLS` session resumption for `IMAP` and `SMTP`.

## Why?

Reduce reconnect latency by avoiding full `TLS` handshakes.

Closes #1174 