### PR TITLE
fix(daemon): add panic recovery

### DIFF
--- a/daemon/handler.go
+++ b/daemon/handler.go
@@ -310,6 +310,17 @@ func (d *Daemon) handleRefreshFolder(conn *daemonrpc.Conn, req *daemonrpc.Reques
 
 	// Async: fetch in background, push events when done.
 	go func() {
+
+		defer func() {
+			if r := recover(); r != nil {
+				d.broadcastToSubscribers(params.AccountID, params.Folder, daemonrpc.EventSyncError, daemonrpc.SyncErrorEvent{
+					AccountID: params.AccountID,
+					Folder:    params.Folder,
+					Error:     fmt.Sprintf("panic: %v", r),
+				})
+			}
+		}()
+
 		p, err := d.getProvider(params.AccountID)
 		if err != nil {
 			log.Printf("daemon: refresh provider error: %v", err)

--- a/daemon/handler.go
+++ b/daemon/handler.go
@@ -310,9 +310,9 @@ func (d *Daemon) handleRefreshFolder(conn *daemonrpc.Conn, req *daemonrpc.Reques
 
 	// Async: fetch in background, push events when done.
 	go func() {
-
 		defer func() {
 			if r := recover(); r != nil {
+				log.Printf("daemon: refresh panic for account = %s folder = %s: %v", params.AccountID, params.Folder, r)
 				d.broadcastToSubscribers(params.AccountID, params.Folder, daemonrpc.EventSyncError, daemonrpc.SyncErrorEvent{
 					AccountID: params.AccountID,
 					Folder:    params.Folder,


### PR DESCRIPTION
## What?

Added panic recovery to the async refresh goroutine in `daemon/handler.go`.

## Why?

The goroutine had no panic recovery. A panic from any provider would crash the entire daemon. Now it recovers and notifies subscribers instead.

Closes #1121 