### PR TITLE
fix: close split view

### DIFF
--- a/main.go
+++ b/main.go
@@ -235,6 +235,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	searchWasActive := false
 	filterWasActive := false
+	splitWasOpen := false
 
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok && keyMsg.String() == config.Keybinds.Global.Cancel {
 		switch current := m.current.(type) {
@@ -246,6 +247,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				searchWasActive = inbox.IsSearchActive()
 				filterWasActive = inbox.IsFilterActive()
 			}
+			splitWasOpen = current.HasSplitPreview()
 		}
 	}
 
@@ -287,7 +289,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case *tui.FilePicker:
 				return m, func() tea.Msg { return tui.CancelFilePickerMsg{} }
 			case *tui.FolderInbox, *tui.Inbox, *tui.Login:
-				if searchWasActive || filterWasActive {
+				if searchWasActive || filterWasActive || splitWasOpen {
 					return m, tea.Batch(cmds...)
 				}
 				m.idleWatcher.StopAll()

--- a/tui/folder_inbox.go
+++ b/tui/folder_inbox.go
@@ -685,6 +685,11 @@ func (m *FolderInbox) GetCurrentFolder() string {
 	return m.currentFolder
 }
 
+// HasSplitPreview reports whether the split preview pane is currently open.
+func (m *FolderInbox) HasSplitPreview() bool {
+	return m.previewPane != nil
+}
+
 // GetInbox returns the embedded inbox.
 func (m *FolderInbox) GetInbox() *Inbox {
 	return m.inbox


### PR DESCRIPTION
## What?

Handles `esc` in split view screen to close the split view, instead of returning to the home screen.

## Why?

Closes #1313 
