### PR TITLE
fix(tui): log image debug

### DIFF
--- a/view/html.go
+++ b/view/html.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"log"
 	"mime/quotedprintable"
 	"os"
 	"regexp"
@@ -273,7 +274,7 @@ func debugImageProtocol(format string, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf("[img-protocol] "+format+"\n", args...)
-	fmt.Print(msg)
+	log.Print(msg)
 	if path := os.Getenv("DEBUG_IMAGE_PROTOCOL_LOG"); path != "" {
 		if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
 			_, _ = f.WriteString(msg)

--- a/view/html.go
+++ b/view/html.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"log"
 	"mime/quotedprintable"
 	"os"
 	"regexp"
@@ -15,6 +14,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/floatpane/matcha/clib"
 	"github.com/floatpane/matcha/internal/httpclient"
+	"github.com/floatpane/matcha/internal/loglevel"
 	"github.com/floatpane/matcha/theme"
 	lru "github.com/hashicorp/golang-lru/v2"
 )
@@ -274,7 +274,7 @@ func debugImageProtocol(format string, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf("[img-protocol] "+format+"\n", args...)
-	log.Print(msg)
+	loglevel.Infof("%s", strings.TrimSuffix(msg, "\n"))
 	if path := os.Getenv("DEBUG_IMAGE_PROTOCOL_LOG"); path != "" {
 		if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
 			_, _ = f.WriteString(msg)

--- a/view/html_test.go
+++ b/view/html_test.go
@@ -1,7 +1,10 @@
 package view
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"regexp"
 	"strings"
@@ -65,6 +68,56 @@ func TestDecodeQuotedPrintable(t *testing.T) {
 				t.Errorf("Expected %q, got %q", tc.expected, decoded)
 			}
 		})
+	}
+}
+
+func TestDebugImageProtocolUsesLogger(t *testing.T) {
+	t.Setenv("DEBUG_IMAGE_PROTOCOL", "1")
+	t.Setenv("DEBUG_IMAGE_PROTOCOL_LOG", "")
+	t.Setenv("DEBUG_KITTY_IMAGES", "")
+	t.Setenv("DEBUG_KITTY_LOG", "")
+
+	var logBuf bytes.Buffer
+	originalLogOutput := log.Writer()
+	originalLogFlags := log.Flags()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(originalLogOutput)
+		log.SetFlags(originalLogFlags)
+	})
+
+	originalStdout := os.Stdout
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+	})
+	os.Stdout = writePipe
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+	})
+
+	debugImageProtocol("hello %s", "world")
+
+	if err := writePipe.Close(); err != nil {
+		t.Fatalf("closing stdout pipe failed: %v", err)
+	}
+	os.Stdout = originalStdout
+	stdout, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("reading stdout pipe failed: %v", err)
+	}
+	if got := string(stdout); got != "" {
+		t.Fatalf("debugImageProtocol wrote to stdout: %q", got)
+	}
+
+	want := "[img-protocol] hello world\n"
+	if got := logBuf.String(); got != want {
+		t.Fatalf("debugImageProtocol log output = %q, want %q", got, want)
 	}
 }
 

--- a/view/html_test.go
+++ b/view/html_test.go
@@ -3,7 +3,6 @@ package view
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"regexp"
@@ -87,33 +86,7 @@ func TestDebugImageProtocolUsesLogger(t *testing.T) {
 		log.SetFlags(originalLogFlags)
 	})
 
-	originalStdout := os.Stdout
-	readPipe, writePipe, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe() failed: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-	})
-	os.Stdout = writePipe
-	t.Cleanup(func() {
-		os.Stdout = originalStdout
-	})
-
 	debugImageProtocol("hello %s", "world")
-
-	if err := writePipe.Close(); err != nil {
-		t.Fatalf("closing stdout pipe failed: %v", err)
-	}
-	os.Stdout = originalStdout
-	stdout, err := io.ReadAll(readPipe)
-	if err != nil {
-		t.Fatalf("reading stdout pipe failed: %v", err)
-	}
-	if got := string(stdout); got != "" {
-		t.Fatalf("debugImageProtocol wrote to stdout: %q", got)
-	}
 
 	want := "[img-protocol] hello world\n"
 	if got := logBuf.String(); got != want {


### PR DESCRIPTION
## What?
- route image protocol debug messages through the standard logger instead of writing directly to stdout
- add coverage that verifies debug output goes to the logger and leaves stdout untouched

## Why?
Debug output should respect the application logging path instead of bypassing logger formatting and destinations.

Fixes #701

## Tests
- go test ./view -count=1
- make lint
- go test ./...