### PR TITLE
fix: keep empty part path

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -323,7 +323,7 @@ func parsePartID(partID string) []int {
 // formatPartPath converts a Walk path like []int{1, 2, 3} to "1.2.3".
 func formatPartPath(path []int) string {
 	if len(path) == 0 {
-		return "1"
+		return ""
 	}
 	parts := make([]string, len(path))
 	for i, p := range path {

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -75,6 +75,20 @@ func TestLookupCharsetEncodingAlwaysReturnsNonNil(t *testing.T) {
 	}
 }
 
+func TestFormatPartPathEmptyPath(t *testing.T) {
+	cases := map[string][]int{
+		"nil":   nil,
+		"empty": {},
+	}
+	for name, path := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := formatPartPath(path); got != "" {
+				t.Fatalf("formatPartPath(%v) = %q, want empty string", path, got)
+			}
+		})
+	}
+}
+
 // TestFetchEmails is an integration test that requires a live IMAP server and valid credentials.
 // NOTE: This test will be skipped if it cannot load a configuration file,
 // making it safe to run in a CI environment without credentials.


### PR DESCRIPTION
## What?

Fixes #1113. `formatPartPath` now returns an empty string for nil/empty paths instead of silently formatting them as part `1`. A regression test covers both nil and empty slices.

## Why?

`parsePartID` already treats an empty string as the nil-path convention, while `1` is a real MIME part. Returning `1` for an empty walk path can mask caller bugs and fetch the wrong part.

Validation:
- `go test ./fetcher -run TestFormatPartPathEmptyPath -count=1`
- `go test ./fetcher -count=1`
- `go test ./...`
- `make lint`
- `git diff --check`