### PR TITLE
fix: remove flowed claim

### DIFF
--- a/sender/sender.go
+++ b/sender/sender.go
@@ -195,6 +195,11 @@ func writeQuotedPrintable(w io.Writer, body string) error {
 	return nil
 }
 
+func writePlainTextPartHeaders(w io.Writer) {
+	fmt.Fprintf(w, "Content-Type: text/plain; charset=UTF-8\r\n")
+	fmt.Fprintf(w, "Content-Transfer-Encoding: quoted-printable\r\n\r\n")
+}
+
 // SendEmail constructs a multipart message with plain text, HTML, embedded images, and attachments.
 func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody, htmlBody string, images map[string][]byte, attachments map[string][]byte, inReplyTo string, references []string, signSMIME bool, encryptSMIME bool, signPGP bool, encryptPGP bool) ([]byte, error) {
 	smtpServer := account.GetSMTPServer()
@@ -263,8 +268,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 
 		// Build the canonical MIME part (headers + body) used for signing/encryption
 		var partBuf bytes.Buffer
-		fmt.Fprintf(&partBuf, "Content-Type: text/plain; charset=UTF-8; format=flowed\r\n")
-		fmt.Fprintf(&partBuf, "Content-Transfer-Encoding: quoted-printable\r\n\r\n")
+		writePlainTextPartHeaders(&partBuf)
 		partBuf.Write(encodedBody)
 		canonicalPart := partBuf.Bytes()
 
@@ -349,8 +353,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 				payloadToEncrypt = canonicalBody
 			} else {
 				// Write Content-Type and body as top-level single part
-				fmt.Fprintf(&msg, "Content-Type: text/plain; charset=UTF-8; format=flowed\r\n")
-				fmt.Fprintf(&msg, "Content-Transfer-Encoding: quoted-printable\r\n\r\n")
+				writePlainTextPartHeaders(&msg)
 				msg.Write(encodedBody)
 			}
 		}

--- a/sender/sender_test.go
+++ b/sender/sender_test.go
@@ -1,6 +1,7 @@
 package sender
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"strings"
@@ -89,6 +90,23 @@ func TestSMTPHelloHostname(t *testing.T) {
 	osHostname = func() (string, error) { return "ignored", errors.New("hostname unavailable") }
 	if got := smtpHelloHostname(); got != "localhost" {
 		t.Fatalf("expected localhost fallback on error, got %q", got)
+	}
+}
+
+func TestWritePlainTextPartHeadersDoesNotClaimFormatFlowed(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePlainTextPartHeaders(&buf)
+
+	got := buf.String()
+	if strings.Contains(got, "format=flowed") {
+		t.Fatalf("plaintext headers should not claim format=flowed: %q", got)
+	}
+	if !strings.Contains(got, "Content-Type: text/plain; charset=UTF-8\r\n") {
+		t.Fatalf("plaintext headers missing content type: %q", got)
+	}
+	if !strings.Contains(got, "Content-Transfer-Encoding: quoted-printable\r\n\r\n") {
+		t.Fatalf("plaintext headers missing quoted-printable encoding: %q", got)
 	}
 }
 


### PR DESCRIPTION
## What?

Fixes #1114. Plaintext-only messages now emit `Content-Type: text/plain; charset=UTF-8` without `format=flowed`, and both plaintext MIME paths share the same header writer. A regression test covers that the header no longer advertises flowed text while keeping quoted-printable encoding.

## Why?

The sender quoted-printable encodes the body but does not implement RFC 3676 format=flowed space-stuffing or soft line break semantics. Advertising `format=flowed` can make conforming clients reflow plain text incorrectly, especially quoted text.

Validation:
- `go test ./sender -run TestWritePlainTextPartHeadersDoesNotClaimFormatFlowed -count=1`
- `go test ./sender -count=1`
- `go test ./...`
- `make lint`
- `git diff --check`