### PR TITLE
fix(sender): fold References header

### DIFF
--- a/sender/sender.go
+++ b/sender/sender.go
@@ -84,6 +84,13 @@ var (
 	osHostname           = os.Hostname
 )
 
+const (
+	recommendedHeaderLineLen   = 78
+	maxReferencesHeaderLineLen = 998
+	referencesHeaderPrefix     = "References: "
+	referencesFoldPrefix       = " "
+)
+
 // smimeOuterBoundary returns a fresh, high-entropy MIME boundary for an S/MIME
 // multipart/signed wrapper. If crypto/rand cannot supply randomness it returns
 // an error rather than degrading to a predictable, time-based fallback.
@@ -113,6 +120,67 @@ func generateMessageID(from string) string {
 		return fmt.Sprintf("<%d.%s>", time.Now().UnixNano(), from)
 	}
 	return fmt.Sprintf("<%x@%s>", buf, from)
+}
+
+func referencesHeaderValue(inReplyTo string, references []string) string {
+	ids := make([]string, 0, len(references)+1)
+	for _, reference := range references {
+		reference = strings.TrimSpace(reference)
+		if reference != "" {
+			ids = append(ids, reference)
+		}
+	}
+	inReplyTo = strings.TrimSpace(inReplyTo)
+	if inReplyTo != "" {
+		ids = append(ids, inReplyTo)
+	}
+	if len(ids) == 0 {
+		return ""
+	}
+
+	ids = trimReferencesHeaderIDs(ids)
+	return foldReferencesHeaderIDs(ids)
+}
+
+func trimReferencesHeaderIDs(ids []string) []string {
+	ids = append([]string(nil), ids...)
+	for len(ids) > 1 && len(referencesHeaderPrefix)+len(strings.Join(ids, " ")) > maxReferencesHeaderLineLen {
+		if len(ids) > 2 {
+			ids = append(ids[:1], ids[2:]...)
+		} else {
+			ids = ids[1:]
+		}
+	}
+	return ids
+}
+
+func foldReferencesHeaderIDs(ids []string) string {
+	firstLineLimit := recommendedHeaderLineLen - len(referencesHeaderPrefix)
+	continuationLineLimit := recommendedHeaderLineLen - len(referencesFoldPrefix)
+	lines := make([]string, 0, len(ids))
+	current := ""
+	currentLimit := firstLineLimit
+
+	for _, id := range ids {
+		if current == "" {
+			current = id
+			continue
+		}
+
+		if len(current)+1+len(id) <= currentLimit {
+			current += " " + id
+			continue
+		}
+
+		lines = append(lines, current)
+		current = id
+		currentLimit = continuationLineLimit
+	}
+	if current != "" {
+		lines = append(lines, current)
+	}
+
+	return strings.Join(lines, "\r\n"+referencesFoldPrefix)
 }
 
 // containsMarkup returns true if the string contains Markdown or HTML elements.
@@ -225,11 +293,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 
 	if inReplyTo != "" {
 		headers["In-Reply-To"] = inReplyTo
-		if len(references) > 0 {
-			headers["References"] = strings.Join(references, " ") + " " + inReplyTo
-		} else {
-			headers["References"] = inReplyTo
-		}
+		headers["References"] = referencesHeaderValue(inReplyTo, references)
 	}
 
 	// prepare final message buffer and S/MIME payload placeholder
@@ -797,11 +861,7 @@ func SendCalendarReply(account *config.Account, to []string, subject, plainBody 
 
 	if inReplyTo != "" {
 		fmt.Fprintf(&msg, "In-Reply-To: %s\r\n", inReplyTo)
-		if len(references) > 0 {
-			fmt.Fprintf(&msg, "References: %s %s\r\n", strings.Join(references, " "), inReplyTo)
-		} else {
-			fmt.Fprintf(&msg, "References: %s\r\n", inReplyTo)
-		}
+		fmt.Fprintf(&msg, "References: %s\r\n", referencesHeaderValue(inReplyTo, references))
 	}
 
 	// Build multipart/mixed containing:

--- a/sender/sender_test.go
+++ b/sender/sender_test.go
@@ -2,6 +2,7 @@ package sender
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -89,6 +90,48 @@ func TestSMTPHelloHostname(t *testing.T) {
 	osHostname = func() (string, error) { return "ignored", errors.New("hostname unavailable") }
 	if got := smtpHelloHostname(); got != "localhost" {
 		t.Fatalf("expected localhost fallback on error, got %q", got)
+	}
+}
+
+func TestReferencesHeaderValueFoldsLines(t *testing.T) {
+	references := []string{
+		"<11111111111111111111111111111111@example.com>",
+		"<22222222222222222222222222222222@example.com>",
+		"<33333333333333333333333333333333@example.com>",
+	}
+
+	value := referencesHeaderValue("<reply@example.com>", references)
+	if !strings.Contains(value, "\r\n ") {
+		t.Fatalf("expected folded References value, got %q", value)
+	}
+
+	for _, line := range strings.Split("References: "+value, "\r\n") {
+		if len(line) > recommendedHeaderLineLen {
+			t.Fatalf("expected folded line to stay within %d chars, got %d: %q", recommendedHeaderLineLen, len(line), line)
+		}
+	}
+}
+
+func TestReferencesHeaderValueTrimsOldestMiddleIDs(t *testing.T) {
+	references := make([]string, 0, 80)
+	for i := 0; i < 80; i++ {
+		references = append(references, fmt.Sprintf("<%032d@example.com>", i))
+	}
+	inReplyTo := "<final@example.com>"
+
+	value := referencesHeaderValue(inReplyTo, references)
+	unfolded := strings.ReplaceAll(value, "\r\n ", " ")
+	if len("References: "+unfolded) > maxReferencesHeaderLineLen {
+		t.Fatalf("expected trimmed References header within %d chars, got %d", maxReferencesHeaderLineLen, len("References: "+unfolded))
+	}
+	if !strings.Contains(unfolded, references[0]) {
+		t.Fatalf("expected root reference %q to be retained in %q", references[0], unfolded)
+	}
+	if strings.Contains(unfolded, references[1]) {
+		t.Fatalf("expected older middle reference %q to be trimmed from %q", references[1], unfolded)
+	}
+	if !strings.Contains(unfolded, inReplyTo) {
+		t.Fatalf("expected in-reply-to %q to be retained in %q", inReplyTo, unfolded)
 	}
 }
 


### PR DESCRIPTION
## What?

Fold `References` header values at RFC 5322 recommended line length, and reuse the formatter for regular email and calendar replies. Very long reference chains now keep the root reference and newest reply context while trimming older middle IDs to stay under the hard line limit.

## Why?

Closes #1115. A deep reply thread could emit one oversized `References` line, which some MTAs reject or truncate. Added sender tests for folding and middle trimming.

Tests: `go test ./sender`; `go test ./...`; `git diff --check`