### PR TITLE
fix(cli): wrap missing config errors

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -32,7 +32,7 @@ func RunConfig(args []string) error {
 	}
 
 	if _, err := os.Stat(target); os.IsNotExist(err) {
-		return fmt.Errorf("file not found: %s", target)
+		return fmt.Errorf("file not found: %s: %w", target, err)
 	}
 
 	cmd := exec.Command(editor, target)

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestRunConfigMissingConfigWrapsNotExist(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	err := RunConfig(nil)
+	if err == nil {
+		t.Fatal("RunConfig() error = nil, want missing config error")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("RunConfig() error = %v, want errors.Is(os.ErrNotExist)", err)
+	}
+}


### PR DESCRIPTION
## What?

Wrap the underlying `os.Stat` error when `matcha config` cannot find the target config/plugin file.

## Why?

This preserves `errors.Is(err, os.ErrNotExist)` for callers while keeping the existing user-facing path in the message.

Closes #690.

## Verification

- `go test ./cli -run TestRunConfigMissingConfigWrapsNotExist -count=1`
- `go test ./cli`
- `go test ./config`
- `go test ./...`
- `make lint`
- `git diff --check`