### PR TITLE
fix(sender): wrap smime cert errors

### DIFF
--- a/sender/sender.go
+++ b/sender/sender.go
@@ -554,6 +554,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 		certsDir := filepath.Join(cfgDir, "certs")
 		var certs []*x509.Certificate
 		var missingCerts []string
+		var missingCertErr error
 
 		for _, em := range allRecipients {
 			em = strings.TrimSpace(em)
@@ -574,16 +575,25 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 
 			certData, err := os.ReadFile(certPath)
 			if err != nil {
+				if missingCertErr == nil {
+					missingCertErr = err
+				}
 				missingCerts = append(missingCerts, em)
 				continue
 			}
 			block, _ := pem.Decode(certData)
 			if block == nil {
+				if missingCertErr == nil {
+					missingCertErr = fmt.Errorf("failed to parse S/MIME certificate PEM: %s", certPath)
+				}
 				missingCerts = append(missingCerts, em)
 				continue
 			}
 			cert, err := x509.ParseCertificate(block.Bytes)
 			if err != nil {
+				if missingCertErr == nil {
+					missingCertErr = err
+				}
 				missingCerts = append(missingCerts, em)
 				continue
 			}
@@ -591,6 +601,9 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 		}
 
 		if len(missingCerts) > 0 {
+			if missingCertErr != nil {
+				return nil, fmt.Errorf("cannot encrypt: missing or invalid S/MIME certificates for: %s: %w", strings.Join(missingCerts, ", "), missingCertErr)
+			}
 			return nil, fmt.Errorf("cannot encrypt: missing or invalid S/MIME certificates for: %s", strings.Join(missingCerts, ", "))
 		}
 

--- a/sender/sender_test.go
+++ b/sender/sender_test.go
@@ -3,8 +3,11 @@ package sender
 import (
 	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/floatpane/matcha/config"
 )
 
 type failingReader struct{}
@@ -26,6 +29,41 @@ func TestWriteQuotedPrintablePropagatesFlushError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "quoted-printable encoding failed") {
 		t.Fatalf("expected quoted-printable context, got %v", err)
+	}
+}
+
+func TestSendEmailSMIMEEncryptionWrapsMissingCertError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	account := &config.Account{
+		Email:           "sender@example.com",
+		ServiceProvider: "custom",
+		SMTPServer:      "smtp.example.com",
+		SMTPPort:        587,
+	}
+
+	_, err := SendEmail(
+		account,
+		[]string{"recipient@example.com"},
+		nil,
+		nil,
+		"Subject",
+		"plain body",
+		"",
+		nil,
+		nil,
+		"",
+		nil,
+		false,
+		true,
+		false,
+		false,
+	)
+	if err == nil {
+		t.Fatal("SendEmail() error = nil, want missing S/MIME certificate error")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("SendEmail() error = %v, want errors.Is(os.ErrNotExist)", err)
 	}
 }
 


### PR DESCRIPTION
## What?

Preserve the underlying S/MIME certificate read/parse error when encryption cannot find or load one or more recipient certificates.

## Why?

The previous aggregate error listed the missing recipients but dropped the original error, so callers could not use `errors.Is(err, os.ErrNotExist)` for missing certificate files.

Closes #693.

## Verification

- `go test ./sender -run TestSendEmailSMIMEEncryptionWrapsMissingCertError -count=1`
- `go test ./sender`
- `go test ./...`
- `make lint`
- `git diff --check`