### PR TITLE
fix: #1329 test confict

### DIFF
--- a/view/html_test.go
+++ b/view/html_test.go
@@ -88,7 +88,7 @@ func TestDebugImageProtocolUsesLogger(t *testing.T) {
 
 	debugImageProtocol("hello %s", "world")
 
-	want := "[img-protocol] hello world\n"
+	want := "info: [img-protocol] hello world\n"
 	if got := logBuf.String(); got != want {
 		t.Fatalf("debugImageProtocol log output = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## What?

Changes the test assertion due to #1329 changing the output to have `info: ` in front of it. Due to the PR not being rebased to have the #1316 commit.

## Why?

Tests fail.