### PR TITLE
chore: sync gomod2nix.toml

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -78,8 +78,8 @@ schema = 3
     hash = 'sha256-GO3az7WiGcwU0OvmocwdfR5ohGRL8NbjscIaMyhAdxE='
 
   [mod.'github.com/cloudflare/circl']
-    version = 'v1.6.2'
-    hash = 'sha256-5knvODjXemxl/8p1k+y1iMF3+iASZCNYcShbpuJNUDo='
+    version = 'v1.6.3'
+    hash = 'sha256-XZm4EastgX67Dgm5BpOEW/PY4aLcHM/O8+Xbz26PuTY='
 
   [mod.'github.com/danieljoos/wincred']
     version = 'v1.2.3'
@@ -112,10 +112,6 @@ schema = 3
   [mod.'github.com/godbus/dbus/v5']
     version = 'v5.2.2'
     hash = 'sha256-j+LicPlXcB1R3oVFPa8cd4yVJLpBx+ca5gXmHqOJSN8='
-
-  [mod.'github.com/golang/protobuf']
-    version = 'v1.5.2'
-    hash = 'sha256-IVwooaIo46iq7euSSVWTBAdKd+2DUaJ67MtBao1DpBI='
 
   [mod.'github.com/google/uuid']
     version = 'v1.6.0'
@@ -186,12 +182,12 @@ schema = 3
     hash = 'sha256-/6Ajm6bIPt5xXNL5mmeNfJh4EZjgFgVlHEwp1TiC5cM='
 
   [mod.'golang.org/x/net']
-    version = 'v0.54.0'
-    hash = 'sha256-/EoIXzTQzK/yP/lxOyx0Z/bhns4FdPTIF4uyt4gIP80='
+    version = 'v0.55.0'
+    hash = 'sha256-Phi2mSmBGOJcvqPPAit3uqF3UP8SKRI9dHj6yTM3s5s='
 
   [mod.'golang.org/x/oauth2']
-    version = 'v0.4.0'
-    hash = 'sha256-Dj9wHbSbs0Ghr9Hef0hSfanaR8L0GShI18jGBT3yNn8='
+    version = 'v0.27.0'
+    hash = 'sha256-TBKV2c/m0SgPqrJSE0ltJXfImrYPafNuziLN25jgsYY='
 
   [mod.'golang.org/x/sync']
     version = 'v0.20.0'
@@ -208,11 +204,3 @@ schema = 3
   [mod.'golang.org/x/text']
     version = 'v0.37.0'
     hash = 'sha256-8XDOnlPIybcDRy89fkjG5VqtIt5Ku+LmaqYhgKl7i1E='
-
-  [mod.'google.golang.org/appengine']
-    version = 'v1.6.7'
-    hash = 'sha256-zIxGRHiq4QBvRqkrhMGMGCaVL4iM4TtlYpAi/hrivS4='
-
-  [mod.'google.golang.org/protobuf']
-    version = 'v1.28.0'
-    hash = 'sha256-p1cVM3OeEErh1WeNRAg4n3zYm/0qPTPmIiWNjRmJiMQ='


### PR DESCRIPTION
## What?

Regenerates `gomod2nix.toml` to reflect the current `go.mod` / `go.sum`.

## Why?

Keeps the Nix build in sync with Go module changes. Without this, `nix build` fails when new or upgraded Go deps are missing from `gomod2nix.toml`. Generated automatically by the gomod2nix sync workflow.