### PR TITLE
test: refactor body cache tests

### DIFF
--- a/config/cache.go
+++ b/config/cache.go
@@ -707,12 +707,7 @@ func saveEmailBodyCache(cache *EmailBodyCache) error {
 // mutate cache state.
 func GetCachedEmailBody(folderName string, uid uint32, accountID string, threshold int) *CachedEmailBody {
 	lru := GetLRUInstance(threshold)
-
-	if node := lru.Get(folderName, uid, accountID); node != nil {
-		return node.Body
-	}
-
-	return nil
+	return lru.Get(folderName, uid, accountID)
 }
 
 func calculateEmailBodySize(body *CachedEmailBody) int {

--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -457,7 +457,6 @@ func TestLRU_ConcurrentReadWrite(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(20)
 	for i := 0; i < 20; i++ {
-		i := i
 		go func() {
 			defer wg.Done()
 			uid := uint32(i % 5)

--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -1,15 +1,13 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
-	"time"
 )
-
-const threshold = 10000
 
 func setup(t *testing.T) {
 	t.Helper()
@@ -19,69 +17,43 @@ func setup(t *testing.T) {
 	resetLRU()
 }
 
-func createBody(uid uint32, accountID, text string) CachedEmailBody {
-	return CachedEmailBody{
-		UID:       uid,
-		AccountID: accountID,
-		Body:      text,
-		CachedAt:  time.Now(),
-		SizeBytes: len(text),
-	}
-}
-
-func createDraft(id, accountID, subject string) Draft {
-	return Draft{
-		ID:        id,
-		AccountID: accountID,
-		To:        "t@e.com",
-		Subject:   subject,
-		Body:      "This is a draft.",
-	}
-}
-
 func TestEmailCache_SaveLoadRoundTrip(t *testing.T) {
 	setup(t)
 
-	email1 := CachedEmail{
-		UID:       1,
-		From:      "t1@e.com",
-		To:        []string{"t2@e.com"},
-		Subject:   "Hello",
-		AccountID: "AC1",
-		IsRead:    false,
-		Date:      time.Now().Truncate(time.Second),
+	e1 := CachedEmail{
+		UID:     1,
+		From:    "t1@e.com",
+		To:      []string{"t2@e.com"},
+		Subject: "Hello",
 	}
 
-	email2 := CachedEmail{
-		UID:       2,
-		From:      "t2@e.com",
-		To:        []string{"t1@e.com"},
-		Subject:   "Hello",
-		AccountID: "AC2",
-		IsRead:    true,
-		Date:      time.Now().Truncate(time.Second),
+	e2 := CachedEmail{
+		UID:     2,
+		From:    "t2@e.com",
+		To:      []string{"t1@e.com"},
+		Subject: "Hello",
 	}
 
-	want := &EmailCache{Emails: []CachedEmail{email1, email2}}
+	input := &EmailCache{Emails: []CachedEmail{e1, e2}}
 
-	if err := SaveEmailCache(want); err != nil {
+	if err := SaveEmailCache(input); err != nil {
 		t.Fatalf("SaveEmailCache: %v", err)
 	}
 
-	emailCache, err := LoadEmailCache()
-
+	output, err := LoadEmailCache()
 	if err != nil {
 		t.Fatalf("LoadEmailCache: %v", err)
 	}
 
-	if len(emailCache.Emails) != len(want.Emails) {
-		t.Fatalf("email count: got %d, want %d", len(emailCache.Emails), len(want.Emails))
+	if len(output.Emails) != len(input.Emails) {
+		t.Fatalf("email count: got %d, want %d", len(output.Emails), len(input.Emails))
 	}
 
-	for i, e := range emailCache.Emails {
-		w := want.Emails[i]
-		if e.UID != w.UID || e.From != w.From || e.Subject != w.Subject || e.IsRead != w.IsRead {
-			t.Errorf("email[%d] mismatch: got %+v, want %+v", i, e, w)
+	for i := range output.Emails {
+		IN := input.Emails[i]
+		OU := output.Emails[i]
+		if IN.UID != OU.UID || IN.From != OU.From || !slices.Equal(IN.To, OU.To) || IN.Subject != OU.Subject {
+			t.Errorf("email[%d] mismatch: got %+v, want %+v", i, OU, IN)
 		}
 	}
 }
@@ -95,9 +67,11 @@ func TestEmailCache_HasEmailCache_FalseWhenMissing(t *testing.T) {
 
 func TestEmailCache_HasEmailCache_TrueAfterSave(t *testing.T) {
 	setup(t)
+
 	if err := SaveEmailCache(&EmailCache{}); err != nil {
 		t.Fatalf("SaveEmailCache: %v", err)
 	}
+
 	if !HasEmailCache() {
 		t.Error("HasEmailCache should be true after save")
 	}
@@ -105,62 +79,106 @@ func TestEmailCache_HasEmailCache_TrueAfterSave(t *testing.T) {
 
 func TestEmailCache_ClearEmailCache(t *testing.T) {
 	setup(t)
-	if err := SaveEmailCache(&EmailCache{Emails: []CachedEmail{{UID: 1, AccountID: "AC1"}}}); err != nil {
+
+	e := CachedEmail{
+		UID:       1,
+		AccountID: "account",
+		From:      "t1@e.com",
+		To:        []string{"t2@e.com"},
+		Subject:   "Hello",
+	}
+
+	if err := SaveEmailCache(&EmailCache{Emails: []CachedEmail{e}}); err != nil {
 		t.Fatalf("SaveEmailCache: %v", err)
 	}
+
 	if err := ClearEmailCache(); err != nil {
 		t.Fatalf("ClearEmailCache: %v", err)
 	}
+
 	if HasEmailCache() {
 		t.Error("HasEmailCache should be false after clear")
-	}
-}
-
-func TestEmailCache_LoadCorruptFile(t *testing.T) {
-	setup(t)
-	if err := SaveEmailCache(&EmailCache{}); err != nil {
-		t.Fatalf("SaveEmailCache: %v", err)
-	}
-	path, err := cacheFile()
-	if err != nil {
-		t.Fatalf("cacheFile: %v", err)
-	}
-	if err := os.WriteFile(path, []byte("{invalid json}"), 0600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	if _, err = LoadEmailCache(); err == nil {
-		t.Error("LoadEmailCache should return an error for corrupt JSON")
 	}
 }
 
 func TestEmailCache_RemoveAccount(t *testing.T) {
 	setup(t)
 
-	email1 := CachedEmail{UID: 1, AccountID: "AC1"}
-	email2 := CachedEmail{UID: 2, AccountID: "AC2"}
-	email3 := CachedEmail{UID: 3, AccountID: "AC3"}
+	e1 := CachedEmail{UID: 1, AccountID: "a1"}
+	e2 := CachedEmail{UID: 2, AccountID: "a2"}
+	e3 := CachedEmail{UID: 3, AccountID: "a3"}
 
-	if err := SaveEmailCache(&EmailCache{Emails: []CachedEmail{email1, email2, email3}}); err != nil {
+	if err := SaveEmailCache(&EmailCache{Emails: []CachedEmail{e1, e2, e3}}); err != nil {
 		t.Fatalf("SaveEmailCache: %v", err)
 	}
 
-	if err := removeAccountFromEmailCache("AC2"); err != nil {
+	if err := removeAccountFromEmailCache("a2"); err != nil {
 		t.Fatalf("removeAccountFromEmailCache: %v", err)
 	}
 
-	emailCache, err := LoadEmailCache()
-
+	output, err := LoadEmailCache()
 	if err != nil {
 		t.Fatalf("LoadEmailCache: %v", err)
 	}
 
-	for _, e := range emailCache.Emails {
-		if e.AccountID == "AC2" {
+	for _, e := range output.Emails {
+		if e.AccountID == "a2" {
 			t.Errorf("found email belonging to removed account AC2: %+v", e)
 		}
 	}
-	if len(emailCache.Emails) != 2 {
-		t.Errorf("expected 1 email remaining, got %d", len(emailCache.Emails))
+}
+
+func TestEmailCache_LoadCorruptFile(t *testing.T) {
+	setup(t)
+
+	if err := SaveEmailCache(&EmailCache{}); err != nil {
+		t.Fatalf("SaveEmailCache: %v", err)
+	}
+
+	path, err := cacheFile()
+	if err != nil {
+		t.Fatalf("cacheFile: %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte("{corrupted json}"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, err = LoadEmailCache(); err == nil {
+		t.Error("LoadEmailCache should return an error for corrupt JSON")
+	}
+}
+
+func TestContacts_SaveLoadRoundTrip(t *testing.T) {
+	setup(t)
+
+	c := Contact{
+		Name:      "t",
+		Email:     "t@e.com",
+		Addresses: []string{"address 1, address 2"},
+	}
+
+	input := &ContactsCache{Contacts: []Contact{c}}
+
+	if err := SaveContactsCache(input); err != nil {
+		t.Fatalf("SaveContactsCache: %v", err)
+	}
+
+	output, err := LoadContactsCache()
+	if err != nil {
+		t.Fatalf("LoadContactsCache: %v", err)
+	}
+
+	if len(output.Contacts) != len(input.Contacts) {
+		t.Fatalf("contacts count mismatch:\n  got:  %d\n  want: %d", len(output.Contacts), len(input.Contacts))
+	}
+
+	for i := range output.Contacts {
+		IN := input.Contacts[i]
+		OU := output.Contacts[i]
+		if IN.Name != OU.Name || IN.Email != OU.Email || !slices.Equal(IN.Addresses, OU.Addresses) {
+			t.Errorf("contact[%d] mismatch: got %+v, want %+v", i, OU, IN)
+		}
 	}
 }
 
@@ -173,16 +191,20 @@ func TestContacts_SearchEmpty(t *testing.T) {
 
 func TestContacts_LoadCorruptFile(t *testing.T) {
 	setup(t)
+
 	path, err := GetContactsCachePath()
 	if err != nil {
 		t.Fatalf("GetContactsCachePath: %v", err)
 	}
+
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(path, []byte("{invalid json}"), 0600); err != nil {
+
+	if err := os.WriteFile(path, []byte("{corrupted json}"), 0600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
+
 	if _, err = LoadContactsCache(); err == nil {
 		t.Error("LoadContactsCache should error on corrupt JSON")
 	}
@@ -190,49 +212,79 @@ func TestContacts_LoadCorruptFile(t *testing.T) {
 
 func TestDrafts_SaveLoadRoundTrip(t *testing.T) {
 	setup(t)
-	d := createDraft("D1", "AC1", "Subject")
+
+	d := Draft{
+		ID:        "draft 1",
+		To:        "d@e.com",
+		Subject:   "Hello World",
+		AccountID: "a1",
+	}
+
 	if err := SaveDraft(d); err != nil {
 		t.Fatalf("SaveDraft: %v", err)
 	}
-	draft := GetDraft("D1")
-	if draft == nil {
+
+	output := GetDraft("draft 1")
+	if output == nil {
 		t.Fatal("GetDraft returned nil")
 	}
-	if draft.Subject != d.Subject || draft.AccountID != d.AccountID {
-		t.Errorf("draft mismatch: got %+v, want %+v", draft, d)
+
+	if output.ID != d.ID || output.To != d.To || output.Subject != d.Subject || output.AccountID != d.AccountID {
+		t.Errorf("draft mismatch: got %+v, want %+v", output, d)
 	}
 }
 
 func TestDrafts_UpdateExisting(t *testing.T) {
 	setup(t)
-	d := createDraft("D1", "AC1", "Subject")
+
+	d := Draft{
+		ID:        "draft 1",
+		To:        "d@e.com",
+		Subject:   "Hello World",
+		AccountID: "a1",
+	}
+
 	if err := SaveDraft(d); err != nil {
 		t.Fatalf("SaveDraft: %v", err)
 	}
-	d.Subject = "Updated"
+
+	d.Subject = "Hello"
 	if err := SaveDraft(d); err != nil {
 		t.Fatalf("SaveDraft (update): %v", err)
 	}
-	all := GetAllDrafts()
-	if len(all) != 1 {
-		t.Fatalf("expected 1 draft after update, got %d", len(all))
+
+	output := GetAllDrafts()
+	if len(output) != 1 {
+		t.Fatalf("expected 1 draft after update, got %d", len(output))
 	}
-	if all[0].Subject != "Updated" {
-		t.Errorf("subject: got %q, want %q", all[0].Subject, "Updated")
+
+	if output[0].Subject != "Hello" {
+		t.Errorf("subject: got %q, want %q", output[0].Subject, "Hello")
 	}
 }
 
 func TestDrafts_Delete(t *testing.T) {
 	setup(t)
-	if err := SaveDraft(createDraft("D1", "AC1", "Subject")); err != nil {
+
+	d := Draft{
+		ID:        "draft 1",
+		To:        "d@e.com",
+		Subject:   "Hello World",
+		AccountID: "a1",
+	}
+
+	if err := SaveDraft(d); err != nil {
 		t.Fatalf("SaveDraft: %v", err)
 	}
-	if err := DeleteDraft("D1"); err != nil {
+
+	if err := DeleteDraft("draft 1"); err != nil {
 		t.Fatalf("DeleteDraft: %v", err)
 	}
-	if GetDraft("D1") != nil {
+
+	if GetDraft("draft 1") != nil {
 		t.Error("deleted draft should return nil")
 	}
+
 	if HasDrafts() {
 		t.Error("HasDrafts should be false after all drafts deleted")
 	}
@@ -240,16 +292,20 @@ func TestDrafts_Delete(t *testing.T) {
 
 func TestDrafts_LoadCorruptFile(t *testing.T) {
 	setup(t)
+
 	path, err := draftsFile()
 	if err != nil {
 		t.Fatalf("draftsFile: %v", err)
 	}
+
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(path, []byte("{invalid json}"), 0600); err != nil {
+
+	if err := os.WriteFile(path, []byte("{corrupted json}"), 0600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
+
 	if _, err = LoadDraftsCache(); err == nil {
 		t.Error("LoadDraftsCache should error on corrupt JSON")
 	}
@@ -257,67 +313,106 @@ func TestDrafts_LoadCorruptFile(t *testing.T) {
 
 func TestEmailBody_SaveLoadRoundTrip(t *testing.T) {
 	setup(t)
-	body := createBody(1, "AC1", "Hello, world!")
+
+	body := CachedEmailBody{
+		UID:       1,
+		AccountID: "account",
+		Body:      "Hello World",
+	}
+
+	threshold := 100 * 1024 * 1024
+
 	if err := SaveEmailBody("INBOX", body, threshold); err != nil {
 		t.Fatalf("SaveEmailBody: %v", err)
 	}
-	got := GetCachedEmailBody("INBOX", 1, "AC1", threshold)
-	if got == nil {
+
+	output := GetCachedEmailBody("INBOX", 1, "account", threshold)
+	if output == nil {
 		t.Fatal("GetCachedEmailBody returned nil")
 	}
-	if got.Body != body.Body {
-		t.Errorf("body text: got %q, want %q", got.Body, body.Body)
+
+	if output.Body != body.Body {
+		t.Errorf("body text: got %q, want %q", output.Body, body.Body)
 	}
 }
 
 func TestEmailBody_FolderIsolation(t *testing.T) {
 	setup(t)
 
-	_ = SaveEmailBody("INBOX", createBody(1, "AC1", "inbox body"), threshold)
-	_ = SaveEmailBody("Sent", createBody(1, "AC1", "sent body"), threshold)
-
-	gotInbox := GetCachedEmailBody("INBOX", 1, "AC1", threshold)
-	gotSent := GetCachedEmailBody("Sent", 1, "AC1", threshold)
-
-	if gotInbox == nil || gotInbox.Body != "inbox body" {
-		t.Errorf("INBOX body: got %v", gotInbox)
+	b1 := CachedEmailBody{
+		UID:       1,
+		AccountID: "account 1",
+		Body:      "Hello INBOX",
 	}
-	if gotSent == nil || gotSent.Body != "sent body" {
-		t.Errorf("Sent body: got %v", gotSent)
+
+	b2 := CachedEmailBody{
+		UID:       2,
+		AccountID: "account 2",
+		Body:      "Hello Sent",
+	}
+
+	threshold := 100 * 1024 * 1024
+
+	_ = SaveEmailBody("INBOX", b1, threshold)
+	_ = SaveEmailBody("Sent", b2, threshold)
+
+	outputInbox := GetCachedEmailBody("INBOX", 1, "account 1", threshold)
+	outputSent := GetCachedEmailBody("Sent", 2, "account 2", threshold)
+
+	if outputInbox == nil || outputInbox.Body != "Hello INBOX" {
+		t.Errorf("INBOX body: got %v", outputInbox)
+	}
+	if outputSent == nil || outputSent.Body != "Hello Sent" {
+		t.Errorf("Sent body: got %v", outputSent)
 	}
 }
 
 func TestEmailBody_PruneRemovesStaleUIDs(t *testing.T) {
 	setup(t)
 
-	_ = SaveEmailBody("INBOX", createBody(1, "AC1", fmt.Sprintf("body %d", 1)), threshold)
-	_ = SaveEmailBody("INBOX", createBody(2, "AC1", fmt.Sprintf("body %d", 2)), threshold)
-	_ = SaveEmailBody("INBOX", createBody(3, "AC1", fmt.Sprintf("body %d", 3)), threshold)
+	b1 := CachedEmailBody{UID: 1, AccountID: "account 1", Body: "body 1"}
+	b2 := CachedEmailBody{UID: 2, AccountID: "account 1", Body: "body 2"}
+	b3 := CachedEmailBody{UID: 3, AccountID: "account 1", Body: "body 3"}
 
-	if err := PruneEmailBodyCache("INBOX", map[uint32]string{2: "AC1"}, threshold); err != nil {
+	threshold := 100 * 1024 * 1024
+
+	_ = SaveEmailBody("INBOX", b1, threshold)
+	_ = SaveEmailBody("INBOX", b2, threshold)
+	_ = SaveEmailBody("INBOX", b3, threshold)
+
+	if err := PruneEmailBodyCache("INBOX", map[uint32]string{2: "account 1"}, threshold); err != nil {
 		t.Fatalf("PruneEmailBodyCache: %v", err)
 	}
-	if GetCachedEmailBody("INBOX", 1, "AC1", threshold) != nil {
+
+	if GetCachedEmailBody("INBOX", 1, "account 1", threshold) != nil {
 		t.Error("UID 1 should have been pruned")
 	}
-	if GetCachedEmailBody("INBOX", 3, "AC1", threshold) != nil {
+
+	if GetCachedEmailBody("INBOX", 3, "account 1", threshold) != nil {
 		t.Error("UID 3 should have been pruned")
 	}
-	if GetCachedEmailBody("INBOX", 2, "AC1", threshold) == nil {
+
+	if GetCachedEmailBody("INBOX", 2, "account 1", threshold) == nil {
 		t.Error("UID 2 should still be cached")
 	}
 }
 
 func TestEmailBody_CorruptBodyCacheFile(t *testing.T) {
 	setup(t)
-	_ = SaveEmailBody("INBOX", createBody(1, "AC1", "valid"), threshold)
+
+	b := CachedEmailBody{UID: 1, AccountID: "account", Body: "Hello World"}
+
+	_ = SaveEmailBody("INBOX", b, 100*1024*1024)
+
 	path, err := bodyCacheFile("INBOX")
 	if err != nil {
 		t.Fatalf("bodyCacheFile: %v", err)
 	}
-	if err := os.WriteFile(path, []byte("{invalid json}"), 0600); err != nil {
+
+	if err := os.WriteFile(path, []byte("{corrupted json}"), 0600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
+
 	if _, err = LoadEmailBodyCache("INBOX"); err == nil {
 		t.Error("LoadEmailBodyCache should error on corrupt JSON")
 	}
@@ -325,64 +420,72 @@ func TestEmailBody_CorruptBodyCacheFile(t *testing.T) {
 
 func TestEmailBodyCache_AttachmentsPreserved(t *testing.T) {
 	setup(t)
-	body := CachedEmailBody{
-		UID:       1,
-		AccountID: "AC1",
-		Body:      "attachment",
-		Attachments: []CachedAttachment{
-			{Filename: "invoice.pdf", PartID: "2", MIMEType: "application/pdf"},
-			{
-				Filename:         "meeting.ics",
-				PartID:           "3",
-				MIMEType:         "text/calendar",
-				IsCalendarInvite: true,
-				CalendarData:     []byte("BEGIN:VCALENDAR\nEND:VCALENDAR"),
-			},
-		},
+
+	a1 := CachedAttachment{
+		Filename: "invoice.pdf",
+		PartID:   "2",
+		MIMEType: "application/pdf",
 	}
 
-	body.SizeBytes = calculateEmailBodySize(&body)
+	a2 := CachedAttachment{
+		Filename: "meeting.ics",
+		PartID:   "3",
+		MIMEType: "text/calendar",
+	}
+
+	body := CachedEmailBody{
+		UID:         1,
+		AccountID:   "account",
+		Body:        "attachment",
+		Attachments: []CachedAttachment{a1, a2},
+	}
+
+	threshold := 100 * 1024 * 1024
 
 	_ = SaveEmailBody("INBOX", body, threshold)
 
-	got := GetCachedEmailBody("INBOX", 1, "AC1", threshold)
-
-	if got == nil {
+	output := GetCachedEmailBody("INBOX", 1, "account", threshold)
+	if output == nil {
 		t.Fatal("GetCachedEmailBody returned nil")
 	}
-	if len(got.Attachments) != 2 {
-		t.Fatalf("expected 2 attachments, got %d", len(got.Attachments))
+
+	if len(output.Attachments) != 2 {
+		t.Fatalf("expected 2 attachments, got %d", len(output.Attachments))
 	}
-	if got.Attachments[0].Filename != "invoice.pdf" {
-		t.Errorf("attachment[0].Filename: got %q", got.Attachments[0].Filename)
+
+	if output.Attachments[0].Filename != "invoice.pdf" {
+		t.Errorf("attachment[0].Filename: got %q", output.Attachments[0].Filename)
 	}
-	if !got.Attachments[1].IsCalendarInvite {
-		t.Error("attachment[1].IsCalendarInvite should be true")
-	}
-	if string(got.Attachments[1].CalendarData) != "BEGIN:VCALENDAR\nEND:VCALENDAR" {
-		t.Errorf("calendar data mismatch: %s", got.Attachments[1].CalendarData)
+
+	if output.Attachments[1].Filename != "meeting.ics" {
+		t.Errorf("attachment[1].Filename: got %q", output.Attachments[1].Filename)
 	}
 }
 
 func TestLRU_EvictsLeastRecentlyUsed(t *testing.T) {
 	setup(t)
 
-	const body = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	body := strings.Repeat("a", 100)
 
-	for _, uid := range []uint32{1, 2, 3} {
-		b := CachedEmailBody{UID: uid, AccountID: "AC1", Body: body, SizeBytes: len(body)}
-		if err := SaveEmailBody("INBOX", b, 250); err != nil {
-			t.Fatalf("SaveEmailBody uid=%d: %v", uid, err)
-		}
-	}
+	threshold := 250
 
-	if GetCachedEmailBody("INBOX", 1, "AC1", threshold) != nil {
+	b1 := CachedEmailBody{UID: 1, AccountID: "account", Body: body, SizeBytes: len(body)}
+	b2 := CachedEmailBody{UID: 2, AccountID: "account", Body: body, SizeBytes: len(body)}
+	b3 := CachedEmailBody{UID: 3, AccountID: "account", Body: body, SizeBytes: len(body)}
+
+	_ = SaveEmailBody("INBOX", b1, threshold)
+	_ = SaveEmailBody("INBOX", b2, threshold)
+	_ = SaveEmailBody("INBOX", b3, threshold)
+
+	if GetCachedEmailBody("INBOX", 1, "account", threshold) != nil {
 		t.Error("UID 1 should have been evicted (LRU)")
 	}
-	if GetCachedEmailBody("INBOX", 2, "AC1", threshold) == nil {
+
+	if GetCachedEmailBody("INBOX", 2, "account", threshold) == nil {
 		t.Error("UID 2 should still be cached")
 	}
-	if GetCachedEmailBody("INBOX", 3, "AC1", threshold) == nil {
+
+	if GetCachedEmailBody("INBOX", 3, "account", threshold) == nil {
 		t.Error("UID 3 should still be cached")
 	}
 }
@@ -391,14 +494,14 @@ func TestLRU_OversizedBodyRejected(t *testing.T) {
 	setup(t)
 
 	body := CachedEmailBody{
-		UID:       99,
-		AccountID: "AC1",
-		Body:      "This is body",
-		SizeBytes: 80,
+		UID:       1,
+		AccountID: "account",
+		Body:      strings.Repeat("a", 100),
 	}
+
 	_ = SaveEmailBody("INBOX", body, 50)
 
-	if GetCachedEmailBody("INBOX", 99, "acc1", 50) != nil {
+	if GetCachedEmailBody("INBOX", 1, "account", 50) != nil {
 		t.Error("oversized body should not be stored in LRU")
 	}
 }
@@ -406,48 +509,113 @@ func TestLRU_OversizedBodyRejected(t *testing.T) {
 func TestLRU_GetPromotesToFront(t *testing.T) {
 	setup(t)
 
-	const body = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	b1 := CachedEmailBody{UID: 1, AccountID: "account", Body: strings.Repeat("a", 50)}
+	b2 := CachedEmailBody{UID: 2, AccountID: "account", Body: strings.Repeat("a", 50)}
 
-	for _, uid := range []uint32{1, 2} {
-		b := CachedEmailBody{UID: uid, AccountID: "AC1", Body: body, SizeBytes: len(body)}
-		_ = SaveEmailBody("INBOX", b, 250)
-	}
+	threshold := 100
 
-	GetCachedEmailBody("INBOX", 1, "AC1", 250)
+	_ = SaveEmailBody("INBOX", b1, threshold)
+	_ = SaveEmailBody("INBOX", b2, threshold)
 
-	b := CachedEmailBody{UID: 3, AccountID: "AC1", Body: body, SizeBytes: len(body)}
-	_ = SaveEmailBody("INBOX", b, 250)
+	GetCachedEmailBody("INBOX", 1, "account", threshold)
 
-	if GetCachedEmailBody("INBOX", 2, "AC1", threshold) != nil {
+	b3 := CachedEmailBody{UID: 3, AccountID: "account", Body: strings.Repeat("a", 50)}
+	_ = SaveEmailBody("INBOX", b3, threshold)
+
+	if GetCachedEmailBody("INBOX", 2, "account", threshold) != nil {
 		t.Error("UID 2 should have been evicted (LRU after promotion of UID 1)")
 	}
-	if GetCachedEmailBody("INBOX", 1, "AC1", threshold) == nil {
+
+	if GetCachedEmailBody("INBOX", 1, "account", threshold) == nil {
 		t.Error("UID 1 should still be cached (was promoted)")
 	}
 }
 
 func TestLRU_DeleteRemovesEntry(t *testing.T) {
 	setup(t)
-	b := createBody(1, "AC1", "to be deleted")
+
+	b := CachedEmailBody{UID: 1, AccountID: "account", Body: strings.Repeat("a", 50)}
+
+	threshold := 100
+
 	_ = SaveEmailBody("INBOX", b, threshold)
-	GetLRUInstance(threshold).Delete("INBOX", 1, "AC1")
-	if GetCachedEmailBody("INBOX", 1, "AC1", threshold) != nil {
+
+	GetLRUInstance(threshold).Delete("INBOX", 1, "account")
+
+	if GetCachedEmailBody("INBOX", 1, "account", threshold) != nil {
 		t.Error("deleted entry should not be retrievable")
 	}
 }
 
 func TestLRU_ThresholdUpdate(t *testing.T) {
 	setup(t)
-	lru1 := GetLRUInstance(threshold)
-	if lru1.threshold != threshold {
-		t.Errorf("threshold: got %d, want %d", lru1.threshold, threshold)
+
+	lru1 := GetLRUInstance(100)
+	if lru1.threshold != 100 {
+		t.Errorf("threshold: got %d, want %d", lru1.threshold, 100)
 	}
-	lru2 := GetLRUInstance(threshold / 2)
-	if lru2.threshold != threshold/2 {
-		t.Errorf("updated threshold: got %d, want %d", lru2.threshold, threshold/2)
+
+	lru2 := GetLRUInstance(50)
+	if lru2.threshold != 50 {
+		t.Errorf("updated threshold: got %d, want %d", lru2.threshold, 50)
 	}
+
 	if lru1 != lru2 {
 		t.Error("GetLRUInstance should always return the same pointer")
+	}
+}
+
+func TestEmailBody_EvictsLeastRecentlyAccessedAcrossFolders(t *testing.T) {
+	setup(t)
+
+	b1 := CachedEmailBody{UID: 1, AccountID: "account", Body: strings.Repeat("a", 50)}
+	b2 := CachedEmailBody{UID: 2, AccountID: "account", Body: strings.Repeat("a", 50)}
+	b3 := CachedEmailBody{UID: 3, AccountID: "account", Body: strings.Repeat("a", 50)}
+
+	_ = SaveEmailBody("INBOX", b1, 100)
+	_ = SaveEmailBody("Sent", b2, 100)
+	_ = SaveEmailBody("Trash", b3, 100)
+
+	if got := GetCachedEmailBody("INBOX", 1, "account", 100); got != nil {
+		t.Error("oldest INBOX body should be evicted from LRU")
+	}
+
+	if got := GetCachedEmailBody("Sent", 2, "account", 100); got == nil {
+		t.Error("recent Archive body should still be cached")
+	}
+
+	if got := GetCachedEmailBody("Trash", 3, "account", 100); got == nil {
+		t.Error("new Sent body should be cached")
+	}
+}
+
+func TestEmailBody_EvictsMultipleEntriesUntilUnderLimit(t *testing.T) {
+	setup(t)
+
+	b1 := CachedEmailBody{UID: 1, AccountID: "account", Body: strings.Repeat("a", 50)}
+	b2 := CachedEmailBody{UID: 2, AccountID: "account", Body: strings.Repeat("a", 50)}
+	b3 := CachedEmailBody{UID: 3, AccountID: "account", Body: strings.Repeat("a", 50)}
+	b4 := CachedEmailBody{UID: 4, AccountID: "account", Body: strings.Repeat("a", 150)}
+
+	_ = SaveEmailBody("INBOX", b1, 150)
+	_ = SaveEmailBody("INBOX", b2, 150)
+	_ = SaveEmailBody("INBOX", b3, 150)
+	_ = SaveEmailBody("INBOX", b4, 150)
+
+	if got := GetCachedEmailBody("INBOX", 1, "account", 150); got != nil {
+		t.Error("UID 1 should have been evicted")
+	}
+
+	if got := GetCachedEmailBody("INBOX", 2, "account", 150); got != nil {
+		t.Error("UID 2 should have been evicted")
+	}
+
+	if got := GetCachedEmailBody("INBOX", 3, "account", 150); got != nil {
+		t.Error("UID 3 should have been evicted")
+	}
+
+	if got := GetCachedEmailBody("INBOX", 4, "account", 150); got == nil {
+		t.Error("new Archive body should be cached")
 	}
 }
 
@@ -456,77 +624,20 @@ func TestLRU_ConcurrentReadWrite(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(20)
-	for i := 0; i < 20; i++ {
-		go func() {
+
+	for i := range 20 {
+		go func(i int) {
 			defer wg.Done()
 			uid := uint32(i % 5)
 			b := CachedEmailBody{
-				UID: uid, AccountID: "AC1",
-				Body:      fmt.Sprintf("body uid=%d goroutine=%d", uid, i),
-				SizeBytes: 40,
+				UID:       uid,
+				AccountID: "account",
+				Body:      "Hello World",
 			}
+
 			_ = SaveEmailBody("INBOX", b, 1000000)
-			_ = GetCachedEmailBody("INBOX", uid, "AC1", 1000000)
-		}()
+			_ = GetCachedEmailBody("INBOX", uid, "account", 1000000)
+		}(i)
 	}
 	wg.Wait()
-}
-
-func TestEmailBody_EvictsLeastRecentlyAccessedAcrossFolders(t *testing.T) {
-	setup(t)
-
-	if err := SaveEmailBody("INBOX", createBody(1, "AC1", "1234567890"), 20); err != nil {
-		t.Fatalf("SaveEmailBody: %v", err)
-	}
-	if err := SaveEmailBody("Archive", createBody(2, "AC1", "1234567890"), 20); err != nil {
-		t.Fatalf("SaveEmailBody: %v", err)
-	}
-
-	if err := SaveEmailBody("Sent", createBody(3, "AC1", "1234567890"), 20); err != nil {
-		t.Fatalf("SaveEmailBody: %v", err)
-	}
-
-	if got := GetCachedEmailBody("INBOX", 1, "AC1", 20); got != nil {
-		t.Error("oldest INBOX body should be evicted from LRU")
-	}
-
-	if got := GetCachedEmailBody("Archive", 2, "AC1", 20); got == nil {
-		t.Error("recent Archive body should still be cached")
-	}
-
-	if got := GetCachedEmailBody("Sent", 3, "AC1", 20); got == nil {
-		t.Error("new Sent body should be cached")
-	}
-}
-
-func TestEmailBody_EvictsMultipleEntriesUntilUnderLimit(t *testing.T) {
-	setup(t)
-
-	for i := uint32(1); i <= 4; i++ {
-		if err := SaveEmailBody("INBOX", createBody(i, "AC1", "1234567890"), 50); err != nil {
-			t.Fatalf("SaveEmailBody: %v", err)
-		}
-	}
-
-	if err := SaveEmailBody("Archive", createBody(5, "AC1", "123456789012345678901234567890"), 50); err != nil {
-		t.Fatalf("SaveEmailBody: %v", err)
-	}
-
-	if got := GetCachedEmailBody("INBOX", 1, "AC1", 50); got != nil {
-		t.Error("UID 1 should have been evicted")
-	}
-	if got := GetCachedEmailBody("INBOX", 2, "AC1", 50); got != nil {
-		t.Error("UID 2 should have been evicted")
-	}
-
-	if got := GetCachedEmailBody("INBOX", 3, "AC1", 50); got == nil {
-		t.Error("UID 3 should still be cached")
-	}
-	if got := GetCachedEmailBody("INBOX", 4, "AC1", 50); got == nil {
-		t.Error("UID 4 should still be cached")
-	}
-
-	if got := GetCachedEmailBody("Archive", 5, "AC1", 50); got == nil {
-		t.Error("new Archive body should be cached")
-	}
 }

--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -1,162 +1,533 @@
 package config
 
 import (
-	"reflect"
-	"strings"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
 
-func TestSaveEmailBodyEvictsLeastRecentlyAccessedAcrossFolders(t *testing.T) {
-	folderCacheTestSetup(t)
+const threshold = 10000
 
-	oldTime := time.Now().Add(-2 * time.Hour)
-	recentTime := time.Now().Add(-1 * time.Hour)
+func setup(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	resetLRU()
+}
 
-	if err := saveEmailBodyCache(&EmailBodyCache{
-		FolderName: "INBOX",
-		Bodies: []CachedEmailBody{
-			{
-				UID:            1,
-				AccountID:      "acct",
-				Body:           strings.Repeat("a", 10),
-				SizeBytes:      10,
-				CachedAt:       oldTime,
-				LastAccessedAt: oldTime,
-			},
-		},
-	}); err != nil {
-		t.Fatalf("save old cache: %v", err)
-	}
-
-	if err := saveEmailBodyCache(&EmailBodyCache{
-		FolderName: "Archive",
-		Bodies: []CachedEmailBody{
-			{
-				UID:            2,
-				AccountID:      "acct",
-				Body:           strings.Repeat("b", 10),
-				SizeBytes:      10,
-				CachedAt:       recentTime,
-				LastAccessedAt: recentTime,
-			},
-		},
-	}); err != nil {
-		t.Fatalf("save recent cache: %v", err)
-	}
-
-	if err := SaveEmailBody("Sent", CachedEmailBody{
-		UID:       3,
-		AccountID: "acct",
-		Body:      strings.Repeat("c", 10),
-	}, 20); err != nil {
-		t.Fatalf("SaveEmailBody: %v", err)
-	}
-
-	inbox, err := LoadEmailBodyCache("INBOX")
-	if err != nil {
-		t.Fatalf("LoadEmailBodyCache(INBOX): %v", err)
-	}
-	if len(inbox.Bodies) != 0 {
-		t.Fatalf("oldest INBOX body should be evicted, got %d bodies", len(inbox.Bodies))
-	}
-
-	archive, err := LoadEmailBodyCache("Archive")
-	if err != nil {
-		t.Fatalf("LoadEmailBodyCache(Archive): %v", err)
-	}
-	if len(archive.Bodies) != 1 || archive.Bodies[0].UID != 2 {
-		t.Fatalf("recent Archive body should remain, got %+v", archive.Bodies)
-	}
-
-	sent, err := LoadEmailBodyCache("Sent")
-	if err != nil {
-		t.Fatalf("LoadEmailBodyCache(Sent): %v", err)
-	}
-	if len(sent.Bodies) != 1 || sent.Bodies[0].UID != 3 {
-		t.Fatalf("new Sent body should remain, got %+v", sent.Bodies)
+func createBody(uid uint32, accountID, text string) CachedEmailBody {
+	return CachedEmailBody{
+		UID:       uid,
+		AccountID: accountID,
+		Body:      text,
+		CachedAt:  time.Now(),
+		SizeBytes: len(text),
 	}
 }
 
-func TestSaveEmailBodyEvictsMultipleEntriesUntilUnderLimit(t *testing.T) {
-	folderCacheTestSetup(t)
-
-	now := time.Now()
-	bodies := make([]CachedEmailBody, 0, 4)
-	for i := 1; i <= 4; i++ {
-		accessedAt := now.Add(-time.Duration(5-i) * time.Minute)
-		bodies = append(bodies, CachedEmailBody{
-			UID:            uint32(i),
-			AccountID:      "acct",
-			Body:           strings.Repeat(string(rune('a'+i-1)), 10),
-			SizeBytes:      10,
-			CachedAt:       accessedAt,
-			LastAccessedAt: accessedAt,
-		})
-	}
-
-	if err := saveEmailBodyCache(&EmailBodyCache{
-		FolderName: "INBOX",
-		Bodies:     bodies,
-	}); err != nil {
-		t.Fatalf("save cache: %v", err)
-	}
-
-	if err := SaveEmailBody("Archive", CachedEmailBody{
-		UID:       5,
-		AccountID: "acct",
-		Body:      strings.Repeat("e", 30),
-	}, 50); err != nil {
-		t.Fatalf("SaveEmailBody: %v", err)
-	}
-
-	inbox, err := LoadEmailBodyCache("INBOX")
-	if err != nil {
-		t.Fatalf("LoadEmailBodyCache(INBOX): %v", err)
-	}
-
-	gotUIDs := make([]uint32, 0, len(inbox.Bodies))
-	for _, body := range inbox.Bodies {
-		gotUIDs = append(gotUIDs, body.UID)
-	}
-	wantUIDs := []uint32{3, 4}
-	if !reflect.DeepEqual(gotUIDs, wantUIDs) {
-		t.Fatalf("remaining INBOX UIDs = %v, want %v", gotUIDs, wantUIDs)
-	}
-
-	archive, err := LoadEmailBodyCache("Archive")
-	if err != nil {
-		t.Fatalf("LoadEmailBodyCache(Archive): %v", err)
-	}
-	if len(archive.Bodies) != 1 || archive.Bodies[0].UID != 5 {
-		t.Fatalf("new Archive body should remain, got %+v", archive.Bodies)
+func createDraft(id, accountID, subject string) Draft {
+	return Draft{
+		ID:        id,
+		AccountID: accountID,
+		To:        "t@e.com",
+		Subject:   subject,
+		Body:      "This is a draft.",
 	}
 }
 
-func TestSaveEmailBodyDropsOversizedReplacement(t *testing.T) {
-	folderCacheTestSetup(t)
+func TestEmailCache_SaveLoadRoundTrip(t *testing.T) {
+	setup(t)
 
-	if err := SaveEmailBody("INBOX", CachedEmailBody{
+	email1 := CachedEmail{
 		UID:       1,
-		AccountID: "acct",
-		Body:      strings.Repeat("a", 10),
-	}, 20); err != nil {
-		t.Fatalf("initial SaveEmailBody: %v", err)
+		From:      "t1@e.com",
+		To:        []string{"t2@e.com"},
+		Subject:   "Hello",
+		AccountID: "AC1",
+		IsRead:    false,
+		Date:      time.Now().Truncate(time.Second),
 	}
 
-	if err := SaveEmailBody("INBOX", CachedEmailBody{
-		UID:       1,
-		AccountID: "acct",
-		Body:      strings.Repeat("b", 25),
-	}, 20); err != nil {
-		t.Fatalf("oversized SaveEmailBody: %v", err)
+	email2 := CachedEmail{
+		UID:       2,
+		From:      "t2@e.com",
+		To:        []string{"t1@e.com"},
+		Subject:   "Hello",
+		AccountID: "AC2",
+		IsRead:    true,
+		Date:      time.Now().Truncate(time.Second),
 	}
 
-	cache, err := LoadEmailBodyCache("INBOX")
+	want := &EmailCache{Emails: []CachedEmail{email1, email2}}
+
+	if err := SaveEmailCache(want); err != nil {
+		t.Fatalf("SaveEmailCache: %v", err)
+	}
+
+	emailCache, err := LoadEmailCache()
+
 	if err != nil {
-		t.Fatalf("LoadEmailBodyCache: %v", err)
+		t.Fatalf("LoadEmailCache: %v", err)
 	}
-	if len(cache.Bodies) != 0 {
-		t.Fatalf("oversized replacement should not remain cached, got %+v", cache.Bodies)
+
+	if len(emailCache.Emails) != len(want.Emails) {
+		t.Fatalf("email count: got %d, want %d", len(emailCache.Emails), len(want.Emails))
+	}
+
+	for i, e := range emailCache.Emails {
+		w := want.Emails[i]
+		if e.UID != w.UID || e.From != w.From || e.Subject != w.Subject || e.IsRead != w.IsRead {
+			t.Errorf("email[%d] mismatch: got %+v, want %+v", i, e, w)
+		}
+	}
+}
+
+func TestEmailCache_HasEmailCache_FalseWhenMissing(t *testing.T) {
+	setup(t)
+	if HasEmailCache() {
+		t.Error("HasEmailCache should be false before any save")
+	}
+}
+
+func TestEmailCache_HasEmailCache_TrueAfterSave(t *testing.T) {
+	setup(t)
+	if err := SaveEmailCache(&EmailCache{}); err != nil {
+		t.Fatalf("SaveEmailCache: %v", err)
+	}
+	if !HasEmailCache() {
+		t.Error("HasEmailCache should be true after save")
+	}
+}
+
+func TestEmailCache_ClearEmailCache(t *testing.T) {
+	setup(t)
+	if err := SaveEmailCache(&EmailCache{Emails: []CachedEmail{{UID: 1, AccountID: "AC1"}}}); err != nil {
+		t.Fatalf("SaveEmailCache: %v", err)
+	}
+	if err := ClearEmailCache(); err != nil {
+		t.Fatalf("ClearEmailCache: %v", err)
+	}
+	if HasEmailCache() {
+		t.Error("HasEmailCache should be false after clear")
+	}
+}
+
+func TestEmailCache_LoadCorruptFile(t *testing.T) {
+	setup(t)
+	if err := SaveEmailCache(&EmailCache{}); err != nil {
+		t.Fatalf("SaveEmailCache: %v", err)
+	}
+	path, err := cacheFile()
+	if err != nil {
+		t.Fatalf("cacheFile: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{invalid json}"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err = LoadEmailCache(); err == nil {
+		t.Error("LoadEmailCache should return an error for corrupt JSON")
+	}
+}
+
+func TestEmailCache_RemoveAccount(t *testing.T) {
+	setup(t)
+
+	email1 := CachedEmail{UID: 1, AccountID: "AC1"}
+	email2 := CachedEmail{UID: 2, AccountID: "AC2"}
+	email3 := CachedEmail{UID: 3, AccountID: "AC3"}
+
+	if err := SaveEmailCache(&EmailCache{Emails: []CachedEmail{email1, email2, email3}}); err != nil {
+		t.Fatalf("SaveEmailCache: %v", err)
+	}
+
+	if err := removeAccountFromEmailCache("AC2"); err != nil {
+		t.Fatalf("removeAccountFromEmailCache: %v", err)
+	}
+
+	emailCache, err := LoadEmailCache()
+
+	if err != nil {
+		t.Fatalf("LoadEmailCache: %v", err)
+	}
+
+	for _, e := range emailCache.Emails {
+		if e.AccountID == "AC2" {
+			t.Errorf("found email belonging to removed account AC2: %+v", e)
+		}
+	}
+	if len(emailCache.Emails) != 2 {
+		t.Errorf("expected 1 email remaining, got %d", len(emailCache.Emails))
+	}
+}
+
+func TestContacts_SearchEmpty(t *testing.T) {
+	setup(t)
+	if results := SearchContacts(""); len(results) != 0 {
+		t.Errorf("SearchContacts(\"\") should return nil, got %d results", len(results))
+	}
+}
+
+func TestContacts_LoadCorruptFile(t *testing.T) {
+	setup(t)
+	path, err := GetContactsCachePath()
+	if err != nil {
+		t.Fatalf("GetContactsCachePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{invalid json}"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err = LoadContactsCache(); err == nil {
+		t.Error("LoadContactsCache should error on corrupt JSON")
+	}
+}
+
+func TestDrafts_SaveLoadRoundTrip(t *testing.T) {
+	setup(t)
+	d := createDraft("D1", "AC1", "Subject")
+	if err := SaveDraft(d); err != nil {
+		t.Fatalf("SaveDraft: %v", err)
+	}
+	draft := GetDraft("D1")
+	if draft == nil {
+		t.Fatal("GetDraft returned nil")
+	}
+	if draft.Subject != d.Subject || draft.AccountID != d.AccountID {
+		t.Errorf("draft mismatch: got %+v, want %+v", draft, d)
+	}
+}
+
+func TestDrafts_UpdateExisting(t *testing.T) {
+	setup(t)
+	d := createDraft("D1", "AC1", "Subject")
+	if err := SaveDraft(d); err != nil {
+		t.Fatalf("SaveDraft: %v", err)
+	}
+	d.Subject = "Updated"
+	if err := SaveDraft(d); err != nil {
+		t.Fatalf("SaveDraft (update): %v", err)
+	}
+	all := GetAllDrafts()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 draft after update, got %d", len(all))
+	}
+	if all[0].Subject != "Updated" {
+		t.Errorf("subject: got %q, want %q", all[0].Subject, "Updated")
+	}
+}
+
+func TestDrafts_Delete(t *testing.T) {
+	setup(t)
+	if err := SaveDraft(createDraft("D1", "AC1", "Subject")); err != nil {
+		t.Fatalf("SaveDraft: %v", err)
+	}
+	if err := DeleteDraft("D1"); err != nil {
+		t.Fatalf("DeleteDraft: %v", err)
+	}
+	if GetDraft("D1") != nil {
+		t.Error("deleted draft should return nil")
+	}
+	if HasDrafts() {
+		t.Error("HasDrafts should be false after all drafts deleted")
+	}
+}
+
+func TestDrafts_LoadCorruptFile(t *testing.T) {
+	setup(t)
+	path, err := draftsFile()
+	if err != nil {
+		t.Fatalf("draftsFile: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{invalid json}"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err = LoadDraftsCache(); err == nil {
+		t.Error("LoadDraftsCache should error on corrupt JSON")
+	}
+}
+
+func TestEmailBody_SaveLoadRoundTrip(t *testing.T) {
+	setup(t)
+	body := createBody(1, "AC1", "Hello, world!")
+	if err := SaveEmailBody("INBOX", body, threshold); err != nil {
+		t.Fatalf("SaveEmailBody: %v", err)
+	}
+	got := GetCachedEmailBody("INBOX", 1, "AC1", threshold)
+	if got == nil {
+		t.Fatal("GetCachedEmailBody returned nil")
+	}
+	if got.Body != body.Body {
+		t.Errorf("body text: got %q, want %q", got.Body, body.Body)
+	}
+}
+
+func TestEmailBody_FolderIsolation(t *testing.T) {
+	setup(t)
+
+	_ = SaveEmailBody("INBOX", createBody(1, "AC1", "inbox body"), threshold)
+	_ = SaveEmailBody("Sent", createBody(1, "AC1", "sent body"), threshold)
+
+	gotInbox := GetCachedEmailBody("INBOX", 1, "AC1", threshold)
+	gotSent := GetCachedEmailBody("Sent", 1, "AC1", threshold)
+
+	if gotInbox == nil || gotInbox.Body != "inbox body" {
+		t.Errorf("INBOX body: got %v", gotInbox)
+	}
+	if gotSent == nil || gotSent.Body != "sent body" {
+		t.Errorf("Sent body: got %v", gotSent)
+	}
+}
+
+func TestEmailBody_PruneRemovesStaleUIDs(t *testing.T) {
+	setup(t)
+
+	_ = SaveEmailBody("INBOX", createBody(1, "AC1", fmt.Sprintf("body %d", 1)), threshold)
+	_ = SaveEmailBody("INBOX", createBody(2, "AC1", fmt.Sprintf("body %d", 2)), threshold)
+	_ = SaveEmailBody("INBOX", createBody(3, "AC1", fmt.Sprintf("body %d", 3)), threshold)
+
+	if err := PruneEmailBodyCache("INBOX", map[uint32]string{2: "AC1"}, threshold); err != nil {
+		t.Fatalf("PruneEmailBodyCache: %v", err)
+	}
+	if GetCachedEmailBody("INBOX", 1, "AC1", threshold) != nil {
+		t.Error("UID 1 should have been pruned")
+	}
+	if GetCachedEmailBody("INBOX", 3, "AC1", threshold) != nil {
+		t.Error("UID 3 should have been pruned")
+	}
+	if GetCachedEmailBody("INBOX", 2, "AC1", threshold) == nil {
+		t.Error("UID 2 should still be cached")
+	}
+}
+
+func TestEmailBody_CorruptBodyCacheFile(t *testing.T) {
+	setup(t)
+	_ = SaveEmailBody("INBOX", createBody(1, "AC1", "valid"), threshold)
+	path, err := bodyCacheFile("INBOX")
+	if err != nil {
+		t.Fatalf("bodyCacheFile: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{invalid json}"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err = LoadEmailBodyCache("INBOX"); err == nil {
+		t.Error("LoadEmailBodyCache should error on corrupt JSON")
+	}
+}
+
+func TestEmailBodyCache_AttachmentsPreserved(t *testing.T) {
+	setup(t)
+	body := CachedEmailBody{
+		UID:       1,
+		AccountID: "AC1",
+		Body:      "attachment",
+		Attachments: []CachedAttachment{
+			{Filename: "invoice.pdf", PartID: "2", MIMEType: "application/pdf"},
+			{
+				Filename:         "meeting.ics",
+				PartID:           "3",
+				MIMEType:         "text/calendar",
+				IsCalendarInvite: true,
+				CalendarData:     []byte("BEGIN:VCALENDAR\nEND:VCALENDAR"),
+			},
+		},
+	}
+
+	body.SizeBytes = calculateEmailBodySize(&body)
+
+	_ = SaveEmailBody("INBOX", body, threshold)
+
+	got := GetCachedEmailBody("INBOX", 1, "AC1", threshold)
+
+	if got == nil {
+		t.Fatal("GetCachedEmailBody returned nil")
+	}
+	if len(got.Attachments) != 2 {
+		t.Fatalf("expected 2 attachments, got %d", len(got.Attachments))
+	}
+	if got.Attachments[0].Filename != "invoice.pdf" {
+		t.Errorf("attachment[0].Filename: got %q", got.Attachments[0].Filename)
+	}
+	if !got.Attachments[1].IsCalendarInvite {
+		t.Error("attachment[1].IsCalendarInvite should be true")
+	}
+	if string(got.Attachments[1].CalendarData) != "BEGIN:VCALENDAR\nEND:VCALENDAR" {
+		t.Errorf("calendar data mismatch: %s", got.Attachments[1].CalendarData)
+	}
+}
+
+func TestLRU_EvictsLeastRecentlyUsed(t *testing.T) {
+	setup(t)
+
+	const body = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	for _, uid := range []uint32{1, 2, 3} {
+		b := CachedEmailBody{UID: uid, AccountID: "AC1", Body: body, SizeBytes: len(body)}
+		if err := SaveEmailBody("INBOX", b, 250); err != nil {
+			t.Fatalf("SaveEmailBody uid=%d: %v", uid, err)
+		}
+	}
+
+	if GetCachedEmailBody("INBOX", 1, "AC1", threshold) != nil {
+		t.Error("UID 1 should have been evicted (LRU)")
+	}
+	if GetCachedEmailBody("INBOX", 2, "AC1", threshold) == nil {
+		t.Error("UID 2 should still be cached")
+	}
+	if GetCachedEmailBody("INBOX", 3, "AC1", threshold) == nil {
+		t.Error("UID 3 should still be cached")
+	}
+}
+
+func TestLRU_OversizedBodyRejected(t *testing.T) {
+	setup(t)
+
+	body := CachedEmailBody{
+		UID:       99,
+		AccountID: "AC1",
+		Body:      "This is body",
+		SizeBytes: 80,
+	}
+	_ = SaveEmailBody("INBOX", body, 50)
+
+	if GetCachedEmailBody("INBOX", 99, "acc1", 50) != nil {
+		t.Error("oversized body should not be stored in LRU")
+	}
+}
+
+func TestLRU_GetPromotesToFront(t *testing.T) {
+	setup(t)
+
+	const body = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+	for _, uid := range []uint32{1, 2} {
+		b := CachedEmailBody{UID: uid, AccountID: "AC1", Body: body, SizeBytes: len(body)}
+		_ = SaveEmailBody("INBOX", b, 250)
+	}
+
+	GetCachedEmailBody("INBOX", 1, "AC1", 250)
+
+	b := CachedEmailBody{UID: 3, AccountID: "AC1", Body: body, SizeBytes: len(body)}
+	_ = SaveEmailBody("INBOX", b, 250)
+
+	if GetCachedEmailBody("INBOX", 2, "AC1", threshold) != nil {
+		t.Error("UID 2 should have been evicted (LRU after promotion of UID 1)")
+	}
+	if GetCachedEmailBody("INBOX", 1, "AC1", threshold) == nil {
+		t.Error("UID 1 should still be cached (was promoted)")
+	}
+}
+
+func TestLRU_DeleteRemovesEntry(t *testing.T) {
+	setup(t)
+	b := createBody(1, "AC1", "to be deleted")
+	_ = SaveEmailBody("INBOX", b, threshold)
+	GetLRUInstance(threshold).Delete("INBOX", 1, "AC1")
+	if GetCachedEmailBody("INBOX", 1, "AC1", threshold) != nil {
+		t.Error("deleted entry should not be retrievable")
+	}
+}
+
+func TestLRU_ThresholdUpdate(t *testing.T) {
+	setup(t)
+	lru1 := GetLRUInstance(threshold)
+	if lru1.threshold != threshold {
+		t.Errorf("threshold: got %d, want %d", lru1.threshold, threshold)
+	}
+	lru2 := GetLRUInstance(threshold / 2)
+	if lru2.threshold != threshold/2 {
+		t.Errorf("updated threshold: got %d, want %d", lru2.threshold, threshold/2)
+	}
+	if lru1 != lru2 {
+		t.Error("GetLRUInstance should always return the same pointer")
+	}
+}
+
+func TestLRU_ConcurrentReadWrite(t *testing.T) {
+	setup(t)
+
+	var wg sync.WaitGroup
+	wg.Add(20)
+	for i := 0; i < 20; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			uid := uint32(i % 5)
+			b := CachedEmailBody{
+				UID: uid, AccountID: "AC1",
+				Body:      fmt.Sprintf("body uid=%d goroutine=%d", uid, i),
+				SizeBytes: 40,
+			}
+			_ = SaveEmailBody("INBOX", b, 1000000)
+			_ = GetCachedEmailBody("INBOX", uid, "AC1", 1000000)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestEmailBody_EvictsLeastRecentlyAccessedAcrossFolders(t *testing.T) {
+	setup(t)
+
+	if err := SaveEmailBody("INBOX", createBody(1, "AC1", "1234567890"), 20); err != nil {
+		t.Fatalf("SaveEmailBody: %v", err)
+	}
+	if err := SaveEmailBody("Archive", createBody(2, "AC1", "1234567890"), 20); err != nil {
+		t.Fatalf("SaveEmailBody: %v", err)
+	}
+
+	if err := SaveEmailBody("Sent", createBody(3, "AC1", "1234567890"), 20); err != nil {
+		t.Fatalf("SaveEmailBody: %v", err)
+	}
+
+	if got := GetCachedEmailBody("INBOX", 1, "AC1", 20); got != nil {
+		t.Error("oldest INBOX body should be evicted from LRU")
+	}
+
+	if got := GetCachedEmailBody("Archive", 2, "AC1", 20); got == nil {
+		t.Error("recent Archive body should still be cached")
+	}
+
+	if got := GetCachedEmailBody("Sent", 3, "AC1", 20); got == nil {
+		t.Error("new Sent body should be cached")
+	}
+}
+
+func TestEmailBody_EvictsMultipleEntriesUntilUnderLimit(t *testing.T) {
+	setup(t)
+
+	for i := uint32(1); i <= 4; i++ {
+		if err := SaveEmailBody("INBOX", createBody(i, "AC1", "1234567890"), 50); err != nil {
+			t.Fatalf("SaveEmailBody: %v", err)
+		}
+	}
+
+	if err := SaveEmailBody("Archive", createBody(5, "AC1", "123456789012345678901234567890"), 50); err != nil {
+		t.Fatalf("SaveEmailBody: %v", err)
+	}
+
+	if got := GetCachedEmailBody("INBOX", 1, "AC1", 50); got != nil {
+		t.Error("UID 1 should have been evicted")
+	}
+	if got := GetCachedEmailBody("INBOX", 2, "AC1", 50); got != nil {
+		t.Error("UID 2 should have been evicted")
+	}
+
+	if got := GetCachedEmailBody("INBOX", 3, "AC1", 50); got == nil {
+		t.Error("UID 3 should still be cached")
+	}
+	if got := GetCachedEmailBody("INBOX", 4, "AC1", 50); got == nil {
+		t.Error("UID 4 should still be cached")
+	}
+
+	if got := GetCachedEmailBody("Archive", 5, "AC1", 50); got == nil {
+		t.Error("new Archive body should be cached")
 	}
 }

--- a/config/lru.go
+++ b/config/lru.go
@@ -101,6 +101,9 @@ func (lru *LRU) evict() {
 }
 
 func (lru *LRU) LoadFromDisk() error {
+	lru.mu.Lock()
+	defer lru.mu.Unlock()
+
 	dir, err := bodyCacheDir()
 
 	if err != nil {

--- a/config/lru.go
+++ b/config/lru.go
@@ -101,9 +101,6 @@ func (lru *LRU) evict() {
 }
 
 func (lru *LRU) LoadFromDisk() error {
-	lru.mu.Lock()
-	defer lru.mu.Unlock()
-
 	dir, err := bodyCacheDir()
 
 	if err != nil {
@@ -216,7 +213,7 @@ func saveEmailBodyToDisk(folder string, body *CachedEmailBody) error {
 	return saveEmailBodyCache(cache)
 }
 
-func (lru *LRU) Get(folder string, uid uint32, accountID string) *Node {
+func (lru *LRU) Get(folder string, uid uint32, accountID string) *CachedEmailBody {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 
@@ -235,7 +232,9 @@ func (lru *LRU) Get(folder string, uid uint32, accountID string) *Node {
 
 	_ = saveEmailBodyToDisk(folder, node.Body)
 
-	return node
+	bodyCopy := *node.Body
+
+	return &bodyCopy
 }
 
 func (lru *LRU) removeKey(key string) {


### PR DESCRIPTION
## What?

Refactors the test suite for email body cache.

## Why?

The previous implementation only covered a few narrow scenarios and failed to test the system under most practical edge cases. 

Closes #887 