### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779694939,
-        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
+        "lastModified": 1779786838,
+        "narHash": "sha256-0geHoGiR5f8qiXg+gO4rSF6Up6Var+kKqiOv9AO/uUc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
+        "rev": "f44f7788c891fbe5542177df78374f8cdab10e8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What?

Updates `flake.lock` to the latest revisions of all flake inputs (`nixpkgs`, `flake-utils`, etc.).

## Why?

Keeps Nix inputs current so contributors and CI build against fresh `nixpkgs`. Picks up upstream security and toolchain fixes. Generated automatically by the flake-lock update workflow on changes to `go.sum`.