### PR TITLE
docs: add commit message length rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ type(scope): short description
 
 Common types: `feat`, `fix`, `docs`, `test`, `ci`, `chore`.
 
+Keep commit messages to 40 characters or fewer.
+
 Examples:
 ```
 feat(compose): add CC/BCC field support


### PR DESCRIPTION
## What?

Adds a contribution guideline that commit messages should be 40 characters or fewer.

## Why?

Keeps commit history concise and easier to scan across logs, changelogs, and review workflows.