### PR TITLE
fix: prevent a fork bomb

### DIFF
--- a/view/main_test.go
+++ b/view/main_test.go
@@ -1,0 +1,18 @@
+package view
+
+import (
+	"os"
+	"testing"
+
+	"github.com/floatpane/termimage"
+)
+
+// TestMain intercepts subprocess invocations made by termimage's sandbox
+// worker (TERMIMAGE_WORKER=1). Without this, a test binary spawned as a
+// worker would re-run the full test suite, which itself triggers more
+// workers — a fork bomb that exhausts RAM and freezes the machine.
+// Mirrors the call in main.go's main().
+func TestMain(m *testing.M) {
+	termimage.MaybeRunWorker()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## What?

Add `view/main_test.go` with `TestMain` calling `termimage.MaybeRunWorker()` before `m.Run()`.

## Why?

termimage.DisplayWithSize` (called by `view.prerenderImage`) sandboxes image decode by spawning `os.Executable()` as subprocess with `TERMIMAGE_WORKER=1`. Worker subprocess MUST call `termimage.MaybeRunWorker()` first to intercept, decode, exit.

`main.go` does this for the real binary. Test binary did not. When `TestProcessBodyWithImageProtocol` ran Kitty/iTerm cases, `prerenderImage` spawned the test binary as worker. Child re-ran full test suite → triggered more `prerenderImage` calls → spawned more children → fork bomb. RAM exhausted, machine froze.