### PR TITLE
fix: maildir fetch errors

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -213,6 +213,7 @@ type Folder struct {
 	Name       string
 	Delimiter  string
 	Attributes []string
+	Unread     uint32
 }
 
 // OutgoingEmail contains everything needed to send an email.

--- a/backend/imap/imap.go
+++ b/backend/imap/imap.go
@@ -183,6 +183,7 @@ func toBackendFolders(folders []fetcher.Folder) []backend.Folder {
 			Name:       f.Name,
 			Delimiter:  f.Delimiter,
 			Attributes: f.Attributes,
+			Unread:     f.Unread,
 		}
 	}
 	return result

--- a/backend/maildir/maildir.go
+++ b/backend/maildir/maildir.go
@@ -39,9 +39,18 @@ func init() {
 }
 
 // Provider implements backend.Provider against a local Maildir tree.
+// Two on-disk layouts are supported:
+//   - Maildir++ (dovecot style): the root itself is INBOX (has cur/new/tmp),
+//     and subfolders are sibling directories prefixed with "." (e.g. ".Sent").
+//   - Nested (mbsync/isync/fastmail style): the root contains one directory
+//     per folder, each holding its own cur/new/tmp. INBOX is the child
+//     directory named "INBOX".
+//
+// The layout is auto-detected at New() time by probing for `<root>/cur`.
 type Provider struct {
 	account *config.Account
 	root    string
+	nested  bool
 }
 
 // New creates a new Maildir provider for the given account.
@@ -68,13 +77,25 @@ func New(account *config.Account) (*Provider, error) {
 		return nil, fmt.Errorf("maildir path %q is not a directory", root)
 	}
 
-	return &Provider{account: account, root: root}, nil
+	nested := false
+	if _, err := os.Stat(filepath.Join(root, "cur")); err != nil {
+		nested = true
+	}
+
+	return &Provider{account: account, root: root, nested: nested}, nil
 }
 
 // dirForFolder resolves a logical folder name to the on-disk Maildir directory.
-// "" and "INBOX" map to the configured root; anything else is treated as a
-// Maildir++ subfolder. "/" in the folder name is converted to "." per spec.
+// Maildir++ layout: "" and "INBOX" map to the root; other names become
+// ".Sub.Folder" siblings. Nested layout: every folder is a child directory
+// named verbatim, with "/" preserved as a path separator.
 func (p *Provider) dirForFolder(folder string) emaildir.Dir {
+	if p.nested {
+		if folder == "" {
+			folder = "INBOX"
+		}
+		return emaildir.Dir(filepath.Join(p.root, filepath.FromSlash(folder)))
+	}
 	if folder == "" || strings.EqualFold(folder, "INBOX") {
 		return emaildir.Dir(p.root)
 	}
@@ -82,15 +103,51 @@ func (p *Provider) dirForFolder(folder string) emaildir.Dir {
 	return emaildir.Dir(filepath.Join(p.root, subdir))
 }
 
-// FetchFolders returns INBOX plus any Maildir++ subfolders found at the root.
-func (p *Provider) FetchFolders(_ context.Context) ([]backend.Folder, error) {
-	folders := []backend.Folder{{Name: "INBOX", Delimiter: "/"}}
+// archiveDir returns the on-disk path of the Archive folder for the active
+// layout (".Archive" under Maildir++, "Archive" under nested).
+func (p *Provider) archiveDir() string {
+	if p.nested {
+		return filepath.Join(p.root, "Archive")
+	}
+	return filepath.Join(p.root, ".Archive")
+}
 
+// FetchFolders returns INBOX plus any subfolders found at the root, using
+// whichever on-disk layout the provider detected.
+func (p *Provider) FetchFolders(_ context.Context) ([]backend.Folder, error) {
 	entries, err := os.ReadDir(p.root)
 	if err != nil {
 		return nil, fmt.Errorf("maildir read root: %w", err)
 	}
 
+	if p.nested {
+		var folders []backend.Folder
+		seenInbox := false
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if name == "." || name == ".." {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(p.root, name, "cur")); err != nil {
+				continue
+			}
+			if strings.EqualFold(name, "INBOX") {
+				seenInbox = true
+				folders = append([]backend.Folder{{Name: "INBOX", Delimiter: "/"}}, folders...)
+				continue
+			}
+			folders = append(folders, backend.Folder{Name: name, Delimiter: "/"})
+		}
+		if !seenInbox {
+			folders = append([]backend.Folder{{Name: "INBOX", Delimiter: "/"}}, folders...)
+		}
+		return folders, nil
+	}
+
+	folders := []backend.Folder{{Name: "INBOX", Delimiter: "/"}}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -99,15 +156,12 @@ func (p *Provider) FetchFolders(_ context.Context) ([]backend.Folder, error) {
 		if !strings.HasPrefix(name, ".") || name == "." || name == ".." {
 			continue
 		}
-		// Sanity check: a Maildir folder has a cur/ subdir.
 		if _, err := os.Stat(filepath.Join(p.root, name, "cur")); err != nil {
 			continue
 		}
-		// Strip leading dot, map "." → "/" for nested folders.
 		logical := strings.ReplaceAll(strings.TrimPrefix(name, "."), ".", "/")
 		folders = append(folders, backend.Folder{Name: logical, Delimiter: "/"})
 	}
-
 	return folders, nil
 }
 
@@ -258,9 +312,9 @@ func (p *Provider) DeleteEmail(_ context.Context, folder string, uid uint32) err
 	return msg.Remove()
 }
 
-// ArchiveEmail moves the message to the ".Archive" subfolder if one exists.
+// ArchiveEmail moves the message to the Archive subfolder if one exists.
 func (p *Provider) ArchiveEmail(ctx context.Context, folder string, uid uint32) error {
-	if _, err := os.Stat(filepath.Join(p.root, ".Archive", "cur")); err != nil {
+	if _, err := os.Stat(filepath.Join(p.archiveDir(), "cur")); err != nil {
 		return backend.ErrNotSupported
 	}
 	return p.MoveEmail(ctx, uid, folder, "Archive")
@@ -288,7 +342,7 @@ func (p *Provider) DeleteEmails(ctx context.Context, folder string, uids []uint3
 
 // ArchiveEmails archives the listed messages.
 func (p *Provider) ArchiveEmails(ctx context.Context, folder string, uids []uint32) error {
-	if _, err := os.Stat(filepath.Join(p.root, ".Archive", "cur")); err != nil {
+	if _, err := os.Stat(filepath.Join(p.archiveDir(), "cur")); err != nil {
 		return backend.ErrNotSupported
 	}
 	for _, uid := range uids {
@@ -421,7 +475,7 @@ func (p *Provider) Close() error { return nil }
 
 // Capabilities reports what the Maildir backend can do.
 func (p *Provider) Capabilities() backend.Capabilities {
-	_, hasArchive := os.Stat(filepath.Join(p.root, ".Archive", "cur"))
+	_, hasArchive := os.Stat(filepath.Join(p.archiveDir(), "cur"))
 	return backend.Capabilities{
 		CanSend:         false,
 		CanMove:         true,

--- a/backend/maildir/maildir.go
+++ b/backend/maildir/maildir.go
@@ -30,6 +30,8 @@ import (
 	"github.com/floatpane/matcha/config"
 )
 
+const inboxFolder = "INBOX"
+
 var messageIDRE = regexp.MustCompile(`<[^>]+>`)
 
 func init() {
@@ -92,11 +94,11 @@ func New(account *config.Account) (*Provider, error) {
 func (p *Provider) dirForFolder(folder string) emaildir.Dir {
 	if p.nested {
 		if folder == "" {
-			folder = "INBOX"
+			folder = inboxFolder
 		}
 		return emaildir.Dir(filepath.Join(p.root, filepath.FromSlash(folder)))
 	}
-	if folder == "" || strings.EqualFold(folder, "INBOX") {
+	if folder == "" || strings.EqualFold(folder, inboxFolder) {
 		return emaildir.Dir(p.root)
 	}
 	subdir := "." + strings.ReplaceAll(folder, "/", ".")
@@ -134,20 +136,20 @@ func (p *Provider) FetchFolders(_ context.Context) ([]backend.Folder, error) {
 			if _, err := os.Stat(filepath.Join(p.root, name, "cur")); err != nil {
 				continue
 			}
-			if strings.EqualFold(name, "INBOX") {
+			if strings.EqualFold(name, inboxFolder) {
 				seenInbox = true
-				folders = append([]backend.Folder{{Name: "INBOX", Delimiter: "/"}}, folders...)
+				folders = append([]backend.Folder{{Name: inboxFolder, Delimiter: "/"}}, folders...)
 				continue
 			}
 			folders = append(folders, backend.Folder{Name: name, Delimiter: "/"})
 		}
 		if !seenInbox {
-			folders = append([]backend.Folder{{Name: "INBOX", Delimiter: "/"}}, folders...)
+			folders = append([]backend.Folder{{Name: inboxFolder, Delimiter: "/"}}, folders...)
 		}
 		return folders, nil
 	}
 
-	folders := []backend.Folder{{Name: "INBOX", Delimiter: "/"}}
+	folders := []backend.Folder{{Name: inboxFolder, Delimiter: "/"}}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue

--- a/backend/maildir/maildir_test.go
+++ b/backend/maildir/maildir_test.go
@@ -288,3 +288,58 @@ func TestCapabilitiesReflectsArchivePresence(t *testing.T) {
 		t.Error("CanFetchFolders must be true")
 	}
 }
+
+// makeNestedMaildir creates an mbsync/isync-style tree: the root has no
+// cur/new/tmp of its own; each named subdirectory is a self-contained
+// Maildir folder.
+func makeNestedMaildir(t *testing.T, folders ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, folder := range folders {
+		for _, sub := range []string{"cur", "new", "tmp"} {
+			if err := os.MkdirAll(filepath.Join(root, folder, sub), 0o755); err != nil {
+				t.Fatalf("mkdir %s/%s: %v", folder, sub, err)
+			}
+		}
+	}
+	return root
+}
+
+func TestNestedLayoutListsFoldersAndFetchesInbox(t *testing.T) {
+	root := makeNestedMaildir(t, "INBOX", "Sent", "Archive", "Drafts")
+	dropMessage(t, filepath.Join(root, "INBOX"), "1700000000.n.host", "nested hi", "body", time.Now())
+
+	p := newProvider(t, root)
+	if !p.nested {
+		t.Fatal("expected nested layout to be detected")
+	}
+
+	folders, err := p.FetchFolders(context.Background())
+	if err != nil {
+		t.Fatalf("FetchFolders: %v", err)
+	}
+	if len(folders) == 0 || folders[0].Name != "INBOX" {
+		t.Errorf("INBOX should be listed first, got %+v", folders)
+	}
+	names := map[string]bool{}
+	for _, f := range folders {
+		names[f.Name] = true
+	}
+	for _, want := range []string{"INBOX", "Sent", "Archive", "Drafts"} {
+		if !names[want] {
+			t.Errorf("missing folder %q in %v", want, names)
+		}
+	}
+
+	emails, err := p.FetchEmails(context.Background(), "INBOX", 10, 0)
+	if err != nil {
+		t.Fatalf("FetchEmails: %v", err)
+	}
+	if len(emails) != 1 || emails[0].Subject != "nested hi" {
+		t.Errorf("want 1 message with subject 'nested hi', got %+v", emails)
+	}
+
+	if !p.Capabilities().CanArchive {
+		t.Error("CanArchive should be true when Archive subfolder exists in nested layout")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -422,6 +422,7 @@ type secureDiskAccount struct {
 	JMAPEndpoint       string `json:"jmap_endpoint,omitempty"`
 	POP3Server         string `json:"pop3_server,omitempty"`
 	POP3Port           int    `json:"pop3_port,omitempty"`
+	MaildirPath        string `json:"maildir_path,omitempty"`
 	CatchAll           bool   `json:"catch_all,omitempty"`
 }
 
@@ -517,6 +518,7 @@ func SaveConfig(config *Config) error {
 				JMAPEndpoint:       acc.JMAPEndpoint,
 				POP3Server:         acc.POP3Server,
 				POP3Port:           acc.POP3Port,
+				MaildirPath:        acc.MaildirPath,
 				CatchAll:           acc.CatchAll,
 			})
 		}
@@ -579,6 +581,7 @@ func LoadConfig() (*Config, error) {
 		JMAPEndpoint       string `json:"jmap_endpoint,omitempty"`
 		POP3Server         string `json:"pop3_server,omitempty"`
 		POP3Port           int    `json:"pop3_port,omitempty"`
+		MaildirPath        string `json:"maildir_path,omitempty"`
 		CatchAll           bool   `json:"catch_all,omitempty"`
 	}
 	type diskConfig struct {
@@ -665,6 +668,7 @@ func LoadConfig() (*Config, error) {
 			JMAPEndpoint:       rawAcc.JMAPEndpoint,
 			POP3Server:         rawAcc.POP3Server,
 			POP3Port:           rawAcc.POP3Port,
+			MaildirPath:        rawAcc.MaildirPath,
 			CatchAll:           rawAcc.CatchAll,
 			SC:                 &SessionCache{},
 		}

--- a/fetcher/dispatch.go
+++ b/fetcher/dispatch.go
@@ -6,19 +6,17 @@ import (
 	"github.com/floatpane/matcha/config"
 )
 
-// backendProvider returns a backend.Provider for accounts whose Protocol
-// is handled by a non-IMAP backend (currently only "maildir"). It returns
-// (nil, nil) for the default IMAP path so callers fall through to the
-// existing imapclient code.
-func backendProvider(account *config.Account) (backend.Provider, error) {
-	if account == nil {
-		return nil, nil
-	}
-	switch account.Protocol {
-	case "maildir":
-		return backend.New(account)
-	}
-	return nil, nil
+// hasBackendProvider reports whether the account is served by a non-IMAP
+// backend (currently only "maildir") and should be routed through the
+// backend.Provider abstraction instead of the legacy IMAP code path.
+func hasBackendProvider(account *config.Account) bool {
+	return account != nil && account.Protocol == "maildir"
+}
+
+// newBackendProvider builds the backend.Provider for the account. Callers
+// must guard with hasBackendProvider before invoking it.
+func newBackendProvider(account *config.Account) (backend.Provider, error) {
+	return backend.New(account)
 }
 
 func backendFoldersToFetcher(in []backend.Folder) []Folder {

--- a/fetcher/dispatch.go
+++ b/fetcher/dispatch.go
@@ -1,0 +1,79 @@
+package fetcher
+
+import (
+	"github.com/floatpane/matcha/backend"
+	_ "github.com/floatpane/matcha/backend/maildir" // register maildir backend
+	"github.com/floatpane/matcha/config"
+)
+
+// backendProvider returns a backend.Provider for accounts whose Protocol
+// is handled by a non-IMAP backend (currently only "maildir"). It returns
+// (nil, nil) for the default IMAP path so callers fall through to the
+// existing imapclient code.
+func backendProvider(account *config.Account) (backend.Provider, error) {
+	if account == nil {
+		return nil, nil
+	}
+	switch account.Protocol {
+	case "maildir":
+		return backend.New(account)
+	}
+	return nil, nil
+}
+
+func backendFoldersToFetcher(in []backend.Folder) []Folder {
+	out := make([]Folder, len(in))
+	for i, f := range in {
+		out[i] = Folder{
+			Name:       f.Name,
+			Delimiter:  f.Delimiter,
+			Attributes: f.Attributes,
+			Unread:     f.Unread,
+		}
+	}
+	return out
+}
+
+func backendEmailsToFetcher(in []backend.Email) []Email {
+	out := make([]Email, len(in))
+	for i, e := range in {
+		out[i] = Email{
+			UID:         e.UID,
+			From:        e.From,
+			To:          e.To,
+			ReplyTo:     e.ReplyTo,
+			Subject:     e.Subject,
+			Body:        e.Body,
+			Date:        e.Date,
+			IsRead:      e.IsRead,
+			MessageID:   e.MessageID,
+			InReplyTo:   e.InReplyTo,
+			References:  e.References,
+			Attachments: backendAttachmentsToFetcher(e.Attachments),
+			AccountID:   e.AccountID,
+		}
+	}
+	return out
+}
+
+func backendAttachmentsToFetcher(in []backend.Attachment) []Attachment {
+	out := make([]Attachment, len(in))
+	for i, a := range in {
+		out[i] = Attachment{
+			Filename:         a.Filename,
+			PartID:           a.PartID,
+			Data:             a.Data,
+			Encoding:         a.Encoding,
+			MIMEType:         a.MIMEType,
+			ContentID:        a.ContentID,
+			Inline:           a.Inline,
+			IsSMIMESignature: a.IsSMIMESignature,
+			SMIMEVerified:    a.SMIMEVerified,
+			IsSMIMEEncrypted: a.IsSMIMEEncrypted,
+			IsPGPSignature:   a.IsPGPSignature,
+			PGPVerified:      a.PGPVerified,
+			IsPGPEncrypted:   a.IsPGPEncrypted,
+		}
+	}
+	return out
+}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -48,6 +48,10 @@ const (
 	mimeTextPlain = "text/plain"
 	mimeTextHTML  = "text/html"
 	partExtracted = "extracted"
+	// defaultArchiveMailbox is the IMAP folder name used as the archive
+	// destination for any provider that does not have a custom mapping
+	// (e.g. Gmail's "[Gmail]/All Mail").
+	defaultArchiveMailbox = "Archive"
 )
 
 func getDebugIMAPWriter() io.Writer {
@@ -493,9 +497,11 @@ func getMailboxByAttr(c *imapclient.Client, attr imap.MailboxAttr) (string, erro
 }
 
 func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset uint32) ([]Email, error) {
-	if p, err := backendProvider(account); err != nil {
-		return nil, err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return nil, err
+		}
 		defer p.Close() //nolint:errcheck
 		emails, err := p.FetchEmails(context.Background(), mailbox, limit, offset)
 		if err != nil {
@@ -658,9 +664,11 @@ func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset u
 // parsed attachments, and any error. The MIME type lets the renderer
 // skip the markdown→HTML pre-pass for already-HTML bodies.
 func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint32) (string, string, []Attachment, error) { //nolint:gocyclo
-	if p, err := backendProvider(account); err != nil {
-		return "", "", nil, err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return "", "", nil, err
+		}
 		defer p.Close() //nolint:errcheck
 		body, mimeType, atts, err := p.FetchEmailBody(context.Background(), mailbox, uid)
 		if err != nil {
@@ -1241,9 +1249,11 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 }
 
 func FetchAttachmentFromMailbox(account *config.Account, mailbox string, uid uint32, partID string, encoding string) ([]byte, error) {
-	if p, err := backendProvider(account); err != nil {
-		return nil, err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return nil, err
+		}
 		defer p.Close() //nolint:errcheck
 		return p.FetchAttachment(context.Background(), mailbox, uid, partID, encoding)
 	}
@@ -1290,9 +1300,11 @@ func FetchAttachmentFromMailbox(account *config.Account, mailbox string, uid uin
 }
 
 func moveEmail(account *config.Account, uid uint32, sourceMailbox, destMailbox string) error {
-	if p, err := backendProvider(account); err != nil {
-		return err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return err
+		}
 		defer p.Close() //nolint:errcheck
 		return p.MoveEmail(context.Background(), uid, sourceMailbox, destMailbox)
 	}
@@ -1313,9 +1325,11 @@ func moveEmail(account *config.Account, uid uint32, sourceMailbox, destMailbox s
 }
 
 func MarkEmailAsReadInMailbox(account *config.Account, mailbox string, uid uint32) error {
-	if p, err := backendProvider(account); err != nil {
-		return err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return err
+		}
 		defer p.Close() //nolint:errcheck
 		return p.MarkAsRead(context.Background(), mailbox, uid)
 	}
@@ -1339,9 +1353,11 @@ func MarkEmailAsReadInMailbox(account *config.Account, mailbox string, uid uint3
 }
 
 func MarkEmailAsUnreadInMailbox(account *config.Account, mailbox string, uid uint32) error {
-	if p, err := backendProvider(account); err != nil {
-		return err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return err
+		}
 		defer p.Close() //nolint:errcheck
 		return p.MarkAsUnread(context.Background(), mailbox, uid)
 	}
@@ -1365,9 +1381,11 @@ func MarkEmailAsUnreadInMailbox(account *config.Account, mailbox string, uid uin
 }
 
 func DeleteEmailFromMailbox(account *config.Account, mailbox string, uid uint32) error {
-	if p, err := backendProvider(account); err != nil {
-		return err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return err
+		}
 		defer p.Close() //nolint:errcheck
 		return p.DeleteEmail(context.Background(), mailbox, uid)
 	}
@@ -1395,9 +1413,11 @@ func DeleteEmailFromMailbox(account *config.Account, mailbox string, uid uint32)
 }
 
 func ArchiveEmailFromMailbox(account *config.Account, mailbox string, uid uint32) error {
-	if p, err := backendProvider(account); err != nil {
-		return err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return err
+		}
 		defer p.Close() //nolint:errcheck
 		return p.ArchiveEmail(context.Background(), mailbox, uid)
 	}
@@ -1418,7 +1438,7 @@ func ArchiveEmailFromMailbox(account *config.Account, mailbox string, uid uint32
 			archiveMailbox = "[Gmail]/All Mail"
 		}
 	default:
-		archiveMailbox = "Archive"
+		archiveMailbox = defaultArchiveMailbox
 	}
 
 	if _, err := c.Select(mailbox, nil).Wait(); err != nil {
@@ -1438,9 +1458,11 @@ func DeleteEmailsFromMailbox(account *config.Account, mailbox string, uids []uin
 		return nil
 	}
 
-	if p, err := backendProvider(account); err != nil {
-		return err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return err
+		}
 		defer p.Close() //nolint:errcheck
 		return p.DeleteEmails(context.Background(), mailbox, uids)
 	}
@@ -1473,9 +1495,11 @@ func ArchiveEmailsFromMailbox(account *config.Account, mailbox string, uids []ui
 		return nil
 	}
 
-	if p, err := backendProvider(account); err != nil {
-		return err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return err
+		}
 		defer p.Close() //nolint:errcheck
 		return p.ArchiveEmails(context.Background(), mailbox, uids)
 	}
@@ -1494,7 +1518,7 @@ func ArchiveEmailsFromMailbox(account *config.Account, mailbox string, uids []ui
 			archiveMailbox = "[Gmail]/All Mail"
 		}
 	default:
-		archiveMailbox = "Archive"
+		archiveMailbox = defaultArchiveMailbox
 	}
 
 	if _, err := c.Select(mailbox, nil).Wait(); err != nil {
@@ -1512,9 +1536,11 @@ func MoveEmailsToFolder(account *config.Account, uids []uint32, sourceFolder, de
 		return nil
 	}
 
-	if p, err := backendProvider(account); err != nil {
-		return err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return err
+		}
 		defer p.Close() //nolint:errcheck
 		return p.MoveEmails(context.Background(), uids, sourceFolder, destFolder)
 	}
@@ -1619,9 +1645,9 @@ func getArchiveMailbox(account *config.Account) string {
 	case config.ProviderGmail:
 		return "[Gmail]/All Mail"
 	case "outlook", "icloud":
-		return "Archive"
+		return defaultArchiveMailbox
 	default:
-		return "Archive"
+		return defaultArchiveMailbox
 	}
 }
 
@@ -1874,9 +1900,11 @@ func DeleteArchiveEmail(account *config.Account, uid uint32) error {
 
 // FetchFolders lists all IMAP folders/mailboxes for an account.
 func FetchFolders(account *config.Account) ([]Folder, error) {
-	if p, err := backendProvider(account); err != nil {
-		return nil, err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return nil, err
+		}
 		defer p.Close() //nolint:errcheck
 		folders, err := p.FetchFolders(context.Background())
 		if err != nil {

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -492,6 +493,17 @@ func getMailboxByAttr(c *imapclient.Client, attr imap.MailboxAttr) (string, erro
 }
 
 func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset uint32) ([]Email, error) {
+	if p, err := backendProvider(account); err != nil {
+		return nil, err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		emails, err := p.FetchEmails(context.Background(), mailbox, limit, offset)
+		if err != nil {
+			return nil, err
+		}
+		return backendEmailsToFetcher(emails), nil
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return nil, err
@@ -646,6 +658,17 @@ func FetchMailboxEmails(account *config.Account, mailbox string, limit, offset u
 // parsed attachments, and any error. The MIME type lets the renderer
 // skip the markdown→HTML pre-pass for already-HTML bodies.
 func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint32) (string, string, []Attachment, error) { //nolint:gocyclo
+	if p, err := backendProvider(account); err != nil {
+		return "", "", nil, err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		body, mimeType, atts, err := p.FetchEmailBody(context.Background(), mailbox, uid)
+		if err != nil {
+			return "", "", nil, err
+		}
+		return body, mimeType, backendAttachmentsToFetcher(atts), nil
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return "", "", nil, err
@@ -1218,6 +1241,13 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 }
 
 func FetchAttachmentFromMailbox(account *config.Account, mailbox string, uid uint32, partID string, encoding string) ([]byte, error) {
+	if p, err := backendProvider(account); err != nil {
+		return nil, err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		return p.FetchAttachment(context.Background(), mailbox, uid, partID, encoding)
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return nil, err
@@ -1260,6 +1290,13 @@ func FetchAttachmentFromMailbox(account *config.Account, mailbox string, uid uin
 }
 
 func moveEmail(account *config.Account, uid uint32, sourceMailbox, destMailbox string) error {
+	if p, err := backendProvider(account); err != nil {
+		return err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		return p.MoveEmail(context.Background(), uid, sourceMailbox, destMailbox)
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return err
@@ -1276,6 +1313,13 @@ func moveEmail(account *config.Account, uid uint32, sourceMailbox, destMailbox s
 }
 
 func MarkEmailAsReadInMailbox(account *config.Account, mailbox string, uid uint32) error {
+	if p, err := backendProvider(account); err != nil {
+		return err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		return p.MarkAsRead(context.Background(), mailbox, uid)
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return err
@@ -1295,6 +1339,13 @@ func MarkEmailAsReadInMailbox(account *config.Account, mailbox string, uid uint3
 }
 
 func MarkEmailAsUnreadInMailbox(account *config.Account, mailbox string, uid uint32) error {
+	if p, err := backendProvider(account); err != nil {
+		return err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		return p.MarkAsUnread(context.Background(), mailbox, uid)
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return err
@@ -1314,6 +1365,13 @@ func MarkEmailAsUnreadInMailbox(account *config.Account, mailbox string, uid uin
 }
 
 func DeleteEmailFromMailbox(account *config.Account, mailbox string, uid uint32) error {
+	if p, err := backendProvider(account); err != nil {
+		return err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		return p.DeleteEmail(context.Background(), mailbox, uid)
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return err
@@ -1337,6 +1395,13 @@ func DeleteEmailFromMailbox(account *config.Account, mailbox string, uid uint32)
 }
 
 func ArchiveEmailFromMailbox(account *config.Account, mailbox string, uid uint32) error {
+	if p, err := backendProvider(account); err != nil {
+		return err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		return p.ArchiveEmail(context.Background(), mailbox, uid)
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return err
@@ -1373,6 +1438,13 @@ func DeleteEmailsFromMailbox(account *config.Account, mailbox string, uids []uin
 		return nil
 	}
 
+	if p, err := backendProvider(account); err != nil {
+		return err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		return p.DeleteEmails(context.Background(), mailbox, uids)
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return err
@@ -1399,6 +1471,13 @@ func DeleteEmailsFromMailbox(account *config.Account, mailbox string, uids []uin
 func ArchiveEmailsFromMailbox(account *config.Account, mailbox string, uids []uint32) error {
 	if len(uids) == 0 {
 		return nil
+	}
+
+	if p, err := backendProvider(account); err != nil {
+		return err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		return p.ArchiveEmails(context.Background(), mailbox, uids)
 	}
 
 	c, err := connect(account)
@@ -1431,6 +1510,13 @@ func ArchiveEmailsFromMailbox(account *config.Account, mailbox string, uids []ui
 func MoveEmailsToFolder(account *config.Account, uids []uint32, sourceFolder, destFolder string) error {
 	if len(uids) == 0 {
 		return nil
+	}
+
+	if p, err := backendProvider(account); err != nil {
+		return err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		return p.MoveEmails(context.Background(), uids, sourceFolder, destFolder)
 	}
 
 	c, err := connect(account)
@@ -1788,6 +1874,17 @@ func DeleteArchiveEmail(account *config.Account, uid uint32) error {
 
 // FetchFolders lists all IMAP folders/mailboxes for an account.
 func FetchFolders(account *config.Account) ([]Folder, error) {
+	if p, err := backendProvider(account); err != nil {
+		return nil, err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		folders, err := p.FetchFolders(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		return backendFoldersToFetcher(folders), nil
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return nil, err

--- a/fetcher/idle.go
+++ b/fetcher/idle.go
@@ -47,6 +47,13 @@ func NewIdleWatcher(notify chan<- IdleUpdate) *IdleWatcher {
 
 // Watch starts (or restarts) an IDLE connection for the given account and folder.
 func (w *IdleWatcher) Watch(account *config.Account, folder string) {
+	// IDLE is an IMAP-only concept; non-IMAP backends (maildir, etc.) have
+	// no remote socket to keep open. Skip silently rather than spinning the
+	// reconnect loop forever.
+	if account != nil && account.Protocol != "" && account.Protocol != "imap" {
+		return
+	}
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 

--- a/fetcher/maildir_dispatch_test.go
+++ b/fetcher/maildir_dispatch_test.go
@@ -1,0 +1,206 @@
+package fetcher
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/floatpane/matcha/config"
+)
+
+// End-to-end coverage for the maildir dispatch path in the fetcher package.
+// These tests exercise the public entry points main.go calls (FetchFolders,
+// FetchMailboxEmails, FetchEmailBodyFromMailbox, MarkEmailAsReadInMailbox)
+// against an on-disk Maildir, mirroring the real TUI flow without an IMAP
+// server.
+
+func seenSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ";2,S"
+	}
+	return ":2,S"
+}
+
+func makeMaildirRoot(t *testing.T, subfolders ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, sub := range []string{"cur", "new", "tmp"} {
+		if err := os.MkdirAll(filepath.Join(root, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	for _, folder := range subfolders {
+		for _, sub := range []string{"cur", "new", "tmp"} {
+			if err := os.MkdirAll(filepath.Join(root, folder, sub), 0o755); err != nil {
+				t.Fatalf("mkdir subfolder %s/%s: %v", folder, sub, err)
+			}
+		}
+	}
+	return root
+}
+
+func dropNewMessage(t *testing.T, folderDir, key, subject, body string, deliveredAt time.Time) {
+	t.Helper()
+	contents := fmt.Sprintf(
+		"From: alice@example.com\r\n"+
+			"To: me@local\r\n"+
+			"Subject: %s\r\n"+
+			"Date: %s\r\n"+
+			"Message-ID: <%s@local>\r\n"+
+			"Content-Type: text/plain; charset=utf-8\r\n"+
+			"\r\n"+
+			"%s\r\n",
+		subject, deliveredAt.Format(time.RFC1123Z), key, body,
+	)
+	path := filepath.Join(folderDir, "new", key)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write message: %v", err)
+	}
+	if err := os.Chtimes(path, deliveredAt, deliveredAt); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+}
+
+func maildirAccount(root string) *config.Account {
+	return &config.Account{
+		ID:          "maildir-acct",
+		Protocol:    "maildir",
+		MaildirPath: root,
+	}
+}
+
+func TestFetcherFetchFoldersMaildir(t *testing.T) {
+	root := makeMaildirRoot(t, ".Sent", ".Archive")
+	acct := maildirAccount(root)
+
+	folders, err := FetchFolders(acct)
+	if err != nil {
+		t.Fatalf("FetchFolders: %v", err)
+	}
+
+	names := make(map[string]bool, len(folders))
+	for _, f := range folders {
+		names[f.Name] = true
+	}
+
+	for _, want := range []string{"INBOX", "Sent", "Archive"} {
+		if !names[want] {
+			t.Errorf("FetchFolders missing %q; got %v", want, names)
+		}
+	}
+}
+
+func TestFetcherFetchMailboxEmailsMaildir(t *testing.T) {
+	root := makeMaildirRoot(t)
+	acct := maildirAccount(root)
+
+	dropNewMessage(t, root, "1700000000.M1.host", "Hello", "body one", time.Unix(1700000000, 0))
+	dropNewMessage(t, root, "1700000100.M1.host", "Second", "body two", time.Unix(1700000100, 0))
+
+	emails, err := FetchMailboxEmails(acct, "INBOX", 10, 0)
+	if err != nil {
+		t.Fatalf("FetchMailboxEmails: %v", err)
+	}
+	if len(emails) != 2 {
+		t.Fatalf("expected 2 emails, got %d", len(emails))
+	}
+
+	// Newest-first ordering — Second was delivered later.
+	if emails[0].Subject != "Second" {
+		t.Errorf("expected first email subject %q, got %q", "Second", emails[0].Subject)
+	}
+	if emails[0].AccountID != acct.ID {
+		t.Errorf("AccountID not propagated: got %q", emails[0].AccountID)
+	}
+	if emails[0].From == "" {
+		t.Errorf("From not parsed")
+	}
+}
+
+func TestFetcherFetchEmailBodyMaildir(t *testing.T) {
+	root := makeMaildirRoot(t)
+	acct := maildirAccount(root)
+
+	dropNewMessage(t, root, "1700000200.M1.host", "Body Test", "the body contents", time.Unix(1700000200, 0))
+
+	emails, err := FetchMailboxEmails(acct, "INBOX", 10, 0)
+	if err != nil {
+		t.Fatalf("FetchMailboxEmails: %v", err)
+	}
+	if len(emails) != 1 {
+		t.Fatalf("expected 1 email, got %d", len(emails))
+	}
+
+	body, _, _, err := FetchEmailBodyFromMailbox(acct, "INBOX", emails[0].UID)
+	if err != nil {
+		t.Fatalf("FetchEmailBodyFromMailbox: %v", err)
+	}
+	if !strings.Contains(body, "the body contents") {
+		t.Errorf("body missing expected text; got %q", body)
+	}
+}
+
+func TestFetcherMarkAsReadMaildir(t *testing.T) {
+	root := makeMaildirRoot(t)
+	acct := maildirAccount(root)
+
+	dropNewMessage(t, root, "1700000300.M1.host", "Mark Me", "x", time.Unix(1700000300, 0))
+
+	// First fetch promotes new/ → cur/ and returns an unread message.
+	emails, err := FetchMailboxEmails(acct, "INBOX", 10, 0)
+	if err != nil {
+		t.Fatalf("first FetchMailboxEmails: %v", err)
+	}
+	if len(emails) != 1 || emails[0].IsRead {
+		t.Fatalf("expected one unread email, got %+v", emails)
+	}
+
+	if err := MarkEmailAsReadInMailbox(acct, "INBOX", emails[0].UID); err != nil {
+		t.Fatalf("MarkEmailAsReadInMailbox: %v", err)
+	}
+
+	// Verify the on-disk filename now carries the Seen flag suffix.
+	curDir := filepath.Join(root, "cur")
+	entries, err := os.ReadDir(curDir)
+	if err != nil {
+		t.Fatalf("read cur/: %v", err)
+	}
+	suffix := seenSuffix()
+	found := false
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), suffix) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a cur/ entry with suffix %q; got %v", suffix, entries)
+	}
+
+	// Re-fetch and confirm IsRead is true now.
+	emails2, err := FetchMailboxEmails(acct, "INBOX", 10, 0)
+	if err != nil {
+		t.Fatalf("second FetchMailboxEmails: %v", err)
+	}
+	if len(emails2) != 1 || !emails2[0].IsRead {
+		t.Fatalf("expected one read email after mark, got %+v", emails2)
+	}
+}
+
+func TestFetcherIMAPPathUnaffected(t *testing.T) {
+	// An account with Protocol="" (IMAP default) and no IMAP server should
+	// still fail with the original IMAP error, proving dispatch only fires
+	// for maildir.
+	acct := &config.Account{ID: "x", Protocol: ""}
+	_, err := FetchFolders(acct)
+	if err == nil {
+		t.Fatal("expected error for empty IMAP server")
+	}
+	if !strings.Contains(err.Error(), "unsupported service_provider") {
+		t.Errorf("expected IMAP-path error, got %v", err)
+	}
+}

--- a/fetcher/search.go
+++ b/fetcher/search.go
@@ -1,6 +1,7 @@
 package fetcher
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -11,6 +12,17 @@ import (
 
 // SearchMailbox searches a mailbox server-side and fetches matching envelopes.
 func SearchMailbox(account *config.Account, folder string, query backend.SearchQuery) ([]Email, error) {
+	if p, err := backendProvider(account); err != nil {
+		return nil, err
+	} else if p != nil {
+		defer p.Close() //nolint:errcheck
+		emails, err := p.Search(context.Background(), folder, query)
+		if err != nil {
+			return nil, err
+		}
+		return backendEmailsToFetcher(emails), nil
+	}
+
 	c, err := connect(account)
 	if err != nil {
 		return nil, err

--- a/fetcher/search.go
+++ b/fetcher/search.go
@@ -12,9 +12,11 @@ import (
 
 // SearchMailbox searches a mailbox server-side and fetches matching envelopes.
 func SearchMailbox(account *config.Account, folder string, query backend.SearchQuery) ([]Email, error) {
-	if p, err := backendProvider(account); err != nil {
-		return nil, err
-	} else if p != nil {
+	if hasBackendProvider(account) {
+		p, err := newBackendProvider(account)
+		if err != nil {
+			return nil, err
+		}
 		defer p.Close() //nolint:errcheck
 		emails, err := p.Search(context.Background(), folder, query)
 		if err != nil {


### PR DESCRIPTION
## What?

Routes all per-account fetch sites in main.go through `m.providers[acct.ID]`.

## Why?

Fixes #1309 
