### PR TITLE
chore: sync gomod2nix.toml

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -117,6 +117,10 @@ schema = 3
     version = 'v0.0.1'
     hash = 'sha256-YQ+g7GhiufcasMU8f0zt6ar46ykXZMHFBPFROt2n17I='
 
+  [mod.'github.com/floatpane/go-openpgp-card-hl']
+    version = 'v0.0.1'
+    hash = 'sha256-qssT4qCMoe9dgFISyCLhthlPe36dBJNnGU1bHjbCpK4='
+
   [mod.'github.com/floatpane/go-uds-jsonrpc']
     version = 'v0.0.1'
     hash = 'sha256-A7M71cI5f640oxbSsBk1WxFFoqJtsPQQ+DsTfgOAm60='


### PR DESCRIPTION
## What?

Regenerates `gomod2nix.toml` to reflect the current `go.mod` / `go.sum`.

## Why?

Keeps the Nix build in sync with Go module changes. Without this, `nix build` fails when new or upgraded Go deps are missing from `gomod2nix.toml`. Generated automatically by the gomod2nix sync workflow.