### PR TITLE
ci: remove release event

### DIFF
--- a/.github/workflows/nixpkgs-bump.yml
+++ b/.github/workflows/nixpkgs-bump.yml
@@ -9,8 +9,6 @@ name: Nixpkgs Bump PR
 #   - Initial matcha package already merged into nixpkgs (this workflow updates, not inits)
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## What?

Removes a release event trigger on nix-pkgs-bump workflow

## Why?

We need to rely on r-ryantm, because it will get merged sooner that way.
