### PR TITLE
fix: sync unread counters after delete/archive operations (Closes #1404)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1810,10 +1810,11 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 				}
 			}
 			m.folderEmails[folderName] = filtered
-			go saveFolderEmailsToCache(folderName, filtered)
-		}
+		go saveFolderEmailsToCache(folderName, filtered)
+	}
 
-		return m, m.deleteFolderEmailCmd(msg.UID, msg.AccountID, folderName, msg.Mailbox)
+	m.syncUnreadBadge()
+	return m, m.deleteFolderEmailCmd(msg.UID, msg.AccountID, folderName, msg.Mailbox)
 
 	case tui.ArchiveEmailMsg:
 		tui.ClearKittyGraphics()
@@ -1843,10 +1844,11 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 				}
 			}
 			m.folderEmails[folderName] = filtered
-			go saveFolderEmailsToCache(folderName, filtered)
-		}
+		go saveFolderEmailsToCache(folderName, filtered)
+	}
 
-		return m, m.archiveFolderEmailCmd(msg.UID, msg.AccountID, folderName, msg.Mailbox)
+	m.syncUnreadBadge()
+	return m, m.archiveFolderEmailCmd(msg.UID, msg.AccountID, folderName, msg.Mailbox)
 
 	case tui.EmailMarkedReadMsg:
 		if msg.Err != nil {
@@ -1905,10 +1907,11 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 				}
 			}
 			m.folderEmails[folderName] = filtered
-			go saveFolderEmailsToCache(folderName, filtered)
-		}
+		go saveFolderEmailsToCache(folderName, filtered)
+	}
 
-		return m, m.batchDeleteEmailsCmd(msg.UIDs, msg.AccountID, folderName, msg.Mailbox, len(msg.UIDs))
+	m.syncUnreadBadge()
+	return m, m.batchDeleteEmailsCmd(msg.UIDs, msg.AccountID, folderName, msg.Mailbox, len(msg.UIDs))
 
 	case tui.BatchArchiveEmailsMsg:
 		tui.ClearKittyGraphics()
@@ -1939,10 +1942,11 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 				}
 			}
 			m.folderEmails[folderName] = filtered
-			go saveFolderEmailsToCache(folderName, filtered)
-		}
+		go saveFolderEmailsToCache(folderName, filtered)
+	}
 
-		return m, m.batchArchiveEmailsCmd(msg.UIDs, msg.AccountID, folderName, msg.Mailbox, len(msg.UIDs))
+	m.syncUnreadBadge()
+	return m, m.batchArchiveEmailsCmd(msg.UIDs, msg.AccountID, folderName, msg.Mailbox, len(msg.UIDs))
 
 	case tui.BatchMoveEmailsMsg:
 		if m.config == nil {


### PR DESCRIPTION


## Problem

After deleting or archiving emails, the unread badge counter does not update immediately. The counter only refreshes on the next fetch cycle, leading to stale UI state.

## Root Cause

Four message handlers in `main.go` remove emails from stores but never call `m.syncUnreadBadge()` to recalculate the dock badge:

- `DeleteEmailMsg` (line 1785)
- `ArchiveEmailMsg` (line 1818)
- `BatchDeleteEmailsMsg` (line 1879)
- `BatchArchiveEmailsMsg` (line 1913)

Compare with `EmailMarkedReadMsg` and `EmailMarkedUnreadMsg` which correctly call `m.syncUnreadBadge()` after updating state.

## Fix

Added `m.syncUnreadBadge()` call before the return statement in all four handlers, consistent with the existing pattern used by `EmailMarkedReadMsg` and `EmailMarkedUnreadMsg`.

Co-authored-by: kuishou68 <54054995+kuishou68@users.noreply.github.com>
Co-authored-by: pojian68 <232320289+pojian68@users.noreply.github.com>
Signed-off-by: lingxiu58 <86288566+lingxiu58@users.noreply.github.com>