### PR TITLE
feat(gitmail): initial

### DIFF
--- a/cli/gitmail_apply.go
+++ b/cli/gitmail_apply.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/floatpane/matcha/gitmail"
+)
+
+// RunApply handles the "matcha apply" subcommand: apply a format-patch email
+// (from a file or stdin) to a local git working tree.
+func RunApply(args []string) error {
+	fs := flag.NewFlagSet("apply", flag.ExitOnError)
+	repo := fs.String("repo", ".", "path to the working tree to apply into")
+	reverse := fs.Bool("reverse", false, "unapply the patch instead of applying it")
+	check := fs.Bool("check", false, "validate only; do not write any files")
+	series := fs.Bool("series", false, "treat the input as an mbox and apply the whole series")
+	help := fs.Bool("h", false, "show help")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *help {
+		fmt.Println("Usage: matcha apply [flags] [patch-file]")
+		fmt.Println("")
+		fmt.Println("Apply a patch received by email (git format-patch / send-email)")
+		fmt.Println("to a local working tree. Reads the patch from the given file, or")
+		fmt.Println("from stdin when no file is given. Never runs git.")
+		fmt.Println("")
+		fmt.Println("Flags:")
+		fs.PrintDefaults()
+		fmt.Println("")
+		fmt.Println("Examples:")
+		fmt.Println("  matcha apply fix.patch --repo ~/src/proj")
+		fmt.Println("  git format-patch -1 --stdout | matcha apply --repo .")
+		fmt.Println("  matcha apply --check series.mbox --series   # dry-run a series")
+		fmt.Println("  matcha apply --reverse fix.patch            # undo it")
+		return nil
+	}
+
+	raw, err := readPatchInput(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	opts := gitmail.Options{Reverse: *reverse, DryRun: *check}
+
+	if *series {
+		summaries, err := gitmail.ApplySeries(raw, *repo, opts)
+		printSummaries(summaries, *check)
+		return err
+	}
+
+	summary, err := gitmail.Apply(raw, *repo, opts)
+	if err != nil {
+		return err
+	}
+	printSummaries([]*gitmail.Summary{summary}, *check)
+	return nil
+}
+
+// readPatchInput reads the patch from path, or from stdin when path is empty.
+func readPatchInput(path string) ([]byte, error) {
+	if path == "" || path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
+}
+
+func printSummaries(summaries []*gitmail.Summary, dryRun bool) {
+	verb := "applied"
+	if dryRun {
+		verb = "would apply"
+	}
+	for _, s := range summaries {
+		if s == nil {
+			continue
+		}
+		if s.CoverLetter {
+			fmt.Printf("cover letter: %s (nothing to apply)\n", s.Subject)
+			continue
+		}
+		fmt.Printf("%s: %s — %s\n", verb, s.Subject, s.Author)
+		for _, f := range s.Files {
+			if f.OldPath != "" && f.OldPath != f.Path {
+				fmt.Printf("  %-8s %s -> %s\n", f.Status, f.OldPath, f.Path)
+			} else {
+				fmt.Printf("  %-8s %s\n", f.Status, f.Path)
+			}
+		}
+	}
+}

--- a/docs/docs/Features/CLI.md
+++ b/docs/docs/Features/CLI.md
@@ -88,6 +88,92 @@ matcha send --from work@company.com --to someone@example.com --subject "Hi" --bo
 | `0` | Email sent successfully |
 | `1` | Error (missing flags, bad config, send failure) |
 
+## matcha apply
+
+Apply a patch you received by email — the output of `git format-patch` /
+`git send-email` — to a local working tree. This is matcha's "git-mail"
+workflow: review a patch in your inbox, then apply it without leaving the
+terminal.
+
+```bash
+matcha apply [patch-file] [flags]
+```
+
+The patch is read from `patch-file`, or from **stdin** when no file is given
+(or when the file is `-`). Matcha **never runs git** — it parses the email and
+writes the file changes directly, confined to the target directory.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--repo` | Working tree to apply into (default: current directory) |
+| `--check` | Validate only — report what would change, write nothing (dry run) |
+| `--reverse` | Unapply the patch instead of applying it |
+| `--series` | Treat the input as an mbox and apply the whole patch series in order |
+| `-h` | Show help |
+
+### Examples
+
+**Apply a saved patch to a project:**
+
+```bash
+matcha apply fix.patch --repo ~/src/myproject
+```
+
+**Pipe a patch straight from git:**
+
+```bash
+git format-patch -1 --stdout | matcha apply --repo .
+```
+
+**Dry-run before committing to it:**
+
+```bash
+matcha apply --check fix.patch --repo ~/src/myproject
+```
+
+**Apply a whole series from an mbox:**
+
+```bash
+matcha apply series.mbox --series --repo ~/src/myproject
+```
+
+**Undo a patch you applied:**
+
+```bash
+matcha apply --reverse fix.patch --repo ~/src/myproject
+```
+
+### How it behaves
+
+- **Transactional (per patch).** Every hunk is matched in memory before
+  anything is written. If a hunk does not apply, the file is left untouched and
+  the command exits non-zero — you never get a half-applied file.
+- **Offset-tolerant, context-exact.** A patch still applies when surrounding
+  edits have shifted the target lines, but the context itself must match —
+  matcha will not silently patch the wrong place.
+- **Path-confined.** Patches whose paths try to escape `--repo` (via `../` or
+  an absolute path) are rejected before any file is touched.
+- **Series caveat.** `--series` is transactional per patch, not across the
+  whole series: if patch 3 of 5 conflicts, patches 1–2 are already written.
+  Use `--check --series` first to validate the whole set.
+
+Matcha does **not** create a git commit, move `HEAD`, or touch the index — it
+only edits files. Commit the result yourself once you are happy with it.
+
+> Under the hood, `matcha apply` uses the standalone
+> [`go-mailpatch`](https://github.com/floatpane/go-mailpatch) (parsing) and
+> [`go-patchapply`](https://github.com/floatpane/go-patchapply) (applying)
+> libraries, extracted from matcha.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Patch applied (or, with `--check`, would apply) cleanly |
+| `1` | Error (parse failure, hunk conflict, unsafe path, missing/existing file) |
+
 ## matcha marketplace
 
 Open the interactive plugin marketplace in the terminal. Fetches the plugin registry from GitHub and displays a browsable list of available plugins.

--- a/gitmail/gitmail.go
+++ b/gitmail/gitmail.go
@@ -1,0 +1,107 @@
+// Package gitmail applies patches received as email to a local git working
+// tree. It is matcha's "git-mail" feature: a message produced by
+// `git format-patch` / `git send-email` can be applied to a checkout without
+// shelling out to git, using floatpane's parser and applier libraries.
+//
+//   - github.com/floatpane/go-mailpatch parses the RFC 5322 message into commit
+//     metadata and a structured diff.
+//   - github.com/floatpane/go-patchapply writes the diff to a directory,
+//     confined to that directory and applied transactionally.
+package gitmail
+
+import (
+	"bytes"
+	"fmt"
+
+	mailpatch "github.com/floatpane/go-mailpatch"
+	patchapply "github.com/floatpane/go-patchapply"
+)
+
+// Options controls how a patch is applied.
+type Options struct {
+	// Reverse unapplies the patch instead of applying it.
+	Reverse bool
+	// DryRun validates the patch against the tree but writes nothing.
+	DryRun bool
+}
+
+// Summary describes the result of applying one patch message.
+type Summary struct {
+	// Subject is the patch subject with its "[PATCH n/m]" prefix stripped.
+	Subject string
+	// Author is the commit author ("Name <email>").
+	Author string
+	// Series is the position within a series, when the subject carried it.
+	Series mailpatch.SeriesInfo
+	// CoverLetter is true when the message is a "0/n" cover letter (nothing to
+	// apply); Files is then empty.
+	CoverLetter bool
+	// Files lists what was created, updated, removed, or renamed.
+	Files []patchapply.FileResult
+}
+
+func (o Options) applyOpts() *patchapply.Options {
+	return &patchapply.Options{Reverse: o.Reverse, DryRun: o.DryRun}
+}
+
+func summarize(p *mailpatch.Patch, files []patchapply.FileResult) *Summary {
+	return &Summary{
+		Subject:     p.Subject,
+		Author:      p.From,
+		Series:      p.Series,
+		CoverLetter: p.IsCoverLetter(),
+		Files:       files,
+	}
+}
+
+// Apply parses a single format-patch email (raw RFC 5322 bytes) and applies it
+// to the working tree rooted at repoDir. A cover letter (a "0/n" message with
+// no diff) applies cleanly as a no-op.
+func Apply(raw []byte, repoDir string, opts Options) (*Summary, error) {
+	p, err := mailpatch.ParseBytes(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse patch: %w", err)
+	}
+	fsys := patchapply.NewDirFS(repoDir)
+	res, err := patchapply.ApplyPatch(fsys, p, opts.applyOpts())
+	if err != nil {
+		return nil, fmt.Errorf("apply %q: %w", p.Subject, err)
+	}
+	return summarize(p, res.Files), nil
+}
+
+// ApplySeries applies every patch in an mbox to repoDir in series order. The
+// cover letter, if present, is summarized but applies nothing.
+//
+// It is not transactional across patches: if patch 3 of 5 conflicts, patches 1
+// and 2 are already written. Pass Options.DryRun first to check the whole
+// series, or reverse the applied prefix yourself on failure.
+func ApplySeries(raw []byte, repoDir string, opts Options) ([]*Summary, error) {
+	series, err := mailpatch.ParseSeries(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("parse series: %w", err)
+	}
+
+	fsys := patchapply.NewDirFS(repoDir)
+	var summaries []*Summary
+
+	if series.Cover != nil {
+		summaries = append(summaries, summarize(series.Cover, nil))
+	}
+	for _, p := range series.Patches {
+		res, err := patchapply.ApplyPatch(fsys, p, opts.applyOpts())
+		if err != nil {
+			return summaries, fmt.Errorf("apply [%d/%d] %q: %w",
+				p.Series.Index, p.Series.Total, p.Subject, err)
+		}
+		summaries = append(summaries, summarize(p, res.Files))
+	}
+	return summaries, nil
+}
+
+// IsPatch reports whether raw looks like an applicable patch email: it parses
+// and carries a diff. Use it to decide whether to offer "apply" on a message.
+func IsPatch(raw []byte) bool {
+	p, err := mailpatch.ParseBytes(raw)
+	return err == nil && p.HasDiff()
+}

--- a/gitmail/gitmail_test.go
+++ b/gitmail/gitmail_test.go
@@ -1,0 +1,97 @@
+package gitmail_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/floatpane/matcha/gitmail"
+)
+
+const patchEmail = `From 9f8e7d6c Mon Sep 17 00:00:00 2001
+From: Ada Lovelace <ada@example.com>
+Date: Mon, 2 Jun 2025 11:30:00 +0000
+Subject: [PATCH 1/1] greet: change the world
+
+---
+ greet.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/greet.txt b/greet.txt
+index 111..222 100644
+--- a/greet.txt
++++ b/greet.txt
+@@ -1,3 +1,3 @@
+ hello
+-world
++there
+ bye
+--
+2.45.1
+`
+
+func TestApply(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "greet.txt"), []byte("hello\nworld\nbye\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := gitmail.Apply([]byte(patchEmail), dir, gitmail.Options{})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if s.Subject != "greet: change the world" {
+		t.Errorf("Subject = %q", s.Subject)
+	}
+	if s.Series.Index != 1 || s.Series.Total != 1 {
+		t.Errorf("Series = %+v", s.Series)
+	}
+	if len(s.Files) != 1 || s.Files[0].Path != "greet.txt" {
+		t.Fatalf("Files = %+v", s.Files)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dir, "greet.txt"))
+	if string(got) != "hello\nthere\nbye\n" {
+		t.Errorf("content = %q", got)
+	}
+}
+
+func TestDryRunWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	orig := []byte("hello\nworld\nbye\n")
+	os.WriteFile(filepath.Join(dir, "greet.txt"), orig, 0o644)
+
+	if _, err := gitmail.Apply([]byte(patchEmail), dir, gitmail.Options{DryRun: true}); err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "greet.txt"))
+	if string(got) != string(orig) {
+		t.Errorf("dry run wrote to disk: %q", got)
+	}
+}
+
+func TestReverse(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "greet.txt"), []byte("hello\nworld\nbye\n"), 0o644)
+
+	if _, err := gitmail.Apply([]byte(patchEmail), dir, gitmail.Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitmail.Apply([]byte(patchEmail), dir, gitmail.Options{Reverse: true}); err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "greet.txt"))
+	if string(got) != "hello\nworld\nbye\n" {
+		t.Errorf("reverse did not restore: %q", got)
+	}
+}
+
+func TestIsPatch(t *testing.T) {
+	if !gitmail.IsPatch([]byte(patchEmail)) {
+		t.Error("IsPatch = false for a real patch")
+	}
+	plain := "Subject: hi\n\njust a normal email, no diff\n"
+	if gitmail.IsPatch([]byte(plain)) {
+		t.Error("IsPatch = true for a non-patch")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,9 @@ require (
 	github.com/floatpane/bubble-overlay v0.0.1
 	github.com/floatpane/go-icalendar v0.0.1
 	github.com/floatpane/go-keybind v0.0.1
+	github.com/floatpane/go-mailpatch v0.0.2
 	github.com/floatpane/go-openpgp-card-hl v0.0.1
+	github.com/floatpane/go-patchapply v0.0.1
 	github.com/floatpane/go-secretbox v0.1.0
 	github.com/floatpane/go-uds-jsonrpc v0.0.1
 	github.com/floatpane/jwz-go v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,12 @@ github.com/floatpane/go-icalendar v0.0.1 h1:lF9NhEI4TobX8valDakAFfCnBhM2GDITWMVy
 github.com/floatpane/go-icalendar v0.0.1/go.mod h1:LSy9G+LwUZtfNIAjLlEVRXkuc2A+hq6+pVCIFOiEAyE=
 github.com/floatpane/go-keybind v0.0.1 h1:UrzPQ4ldR9sKQt/efpUfcs6gH8Mwy2NO5vwFTVf0dy0=
 github.com/floatpane/go-keybind v0.0.1/go.mod h1:B8l43ypYOcjknyaHgU0EXUAbrUvfnV2HOzYSzyqcPJI=
+github.com/floatpane/go-mailpatch v0.0.2 h1:ZkV44HiK+8Qx+7TIGdtoetfVuURKZcFWIBmmcrJTwTk=
+github.com/floatpane/go-mailpatch v0.0.2/go.mod h1:mbnMyEWq+x+AH49ysRnSjKN8ZgbbxfYRX2mCQw3n82c=
 github.com/floatpane/go-openpgp-card-hl v0.0.1 h1:1DYmzwGDb8eneZxbc/xtwjXeFY8DFL3eYnUooMT0L0w=
 github.com/floatpane/go-openpgp-card-hl v0.0.1/go.mod h1:Mrx+ukCnpEpMAxyB0p8Ch2gu78Q3Ir40BxBybb2jirw=
+github.com/floatpane/go-patchapply v0.0.1 h1:VtCBe1HfG645axYzHqIGTLZgmmM9Tkoyd7XRJ74y6Ek=
+github.com/floatpane/go-patchapply v0.0.1/go.mod h1:YekZ5hy6gosCoYujvbKuB+cOvy1+lPPC0S/nTpThGQ4=
 github.com/floatpane/go-secretbox v0.1.0 h1:xNryazmCP0oR/yVxIkHRc5bcV56YrbisY+bMl8BBfwU=
 github.com/floatpane/go-secretbox v0.1.0/go.mod h1:uNVTLb1jty9ZT5HIp3zdFIB3K4V3r2V38QaI+bWMVao=
 github.com/floatpane/go-uds-jsonrpc v0.0.1 h1:/sBlCXVAP9SyLWLj0wlFI07dX/SfXeUM67B4tRwK2QA=

--- a/main.go
+++ b/main.go
@@ -4026,6 +4026,15 @@ func main() { //nolint:gocyclo
 		exit(0)
 	}
 
+	// Apply patch CLI subcommand: matcha apply [patch-file] --repo <dir>
+	if len(os.Args) > 1 && os.Args[1] == "apply" {
+		if err := matchaCli.RunApply(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "apply failed: %v\n", err)
+			exit(1)
+		}
+		exit(0)
+	}
+
 	// Install plugin CLI subcommand: matcha install <url_or_file>
 	if len(os.Args) > 1 && os.Args[1] == "install" {
 		if err := matchaCli.RunInstall(os.Args[2:]); err != nil {


### PR DESCRIPTION
## What?

Adds a git-mail apply workflow to matcha: take a `git format-patch` / `git send-email` message and apply it to a local working tree, without shelling out to git.

## Why?

Part of #1411 (not fully done)
