### PR TITLE
chore: use bubble-overlay v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/emersion/go-message v0.18.2
 	github.com/emersion/go-pgpmail v0.2.2
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
-	github.com/floatpane/bubble-overlay v0.0.1
+	github.com/floatpane/bubble-overlay v0.1.0
 	github.com/floatpane/go-icalendar v0.0.1
 	github.com/floatpane/go-keybind v0.0.1
 	github.com/floatpane/go-mailpatch v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/emersion/go-pgpmail v0.2.2/go.mod h1:mRB5P7QKiAuOvcT36tdRZvm7nSt7V+f6
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
 github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594/go.mod h1:aqO8z8wPrjkscevZJFVE1wXJrLpC5LtJG7fqLOsPb2U=
-github.com/floatpane/bubble-overlay v0.0.1 h1:5xU8cNigDPYegvgGMfOG23fIDXhrqXPvLTaEB7uHGK4=
-github.com/floatpane/bubble-overlay v0.0.1/go.mod h1:Csi1byxb9L8EAb8X13XdWF5aX5YiBD5C9WEWACyGa8A=
+github.com/floatpane/bubble-overlay v0.1.0 h1:W/D7/U7VEBHJRiIyMpadQrBCJUfvs/Xb6zXJgHzFFZI=
+github.com/floatpane/bubble-overlay v0.1.0/go.mod h1:quqZnQYU56JLcQYbOGlYFc9Yk4v5jwkx1lozuRQoaio=
 github.com/floatpane/go-icalendar v0.0.1 h1:lF9NhEI4TobX8valDakAFfCnBhM2GDITWMVymhXzD8c=
 github.com/floatpane/go-icalendar v0.0.1/go.mod h1:LSy9G+LwUZtfNIAjLlEVRXkuc2A+hq6+pVCIFOiEAyE=
 github.com/floatpane/go-keybind v0.0.1 h1:UrzPQ4ldR9sKQt/efpUfcs6gH8Mwy2NO5vwFTVf0dy0=

--- a/tui/command_palette.go
+++ b/tui/command_palette.go
@@ -6,6 +6,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	overlay "github.com/floatpane/bubble-overlay"
 	"github.com/floatpane/matcha/theme"
 )
 
@@ -222,38 +223,8 @@ func (p *CommandPalette) renderRow(cmd PaletteCommand, selected bool, inner int)
 }
 
 // Render composites the palette box as a floating layer centered over the given
-// background, using a lipgloss canvas so the background stays visible on every
-// side of the box (only the box's own rectangle is drawn over).
+// background using overlay.Center from github.com/floatpane/bubble-overlay.
+// The background is preserved on all sides; only the box's own cells are replaced.
 func (p *CommandPalette) Render(background string, screenW, screenH int) string {
-	box := p.View()
-	boxW, boxH := lipgloss.Width(box), lipgloss.Height(box)
-
-	col := (screenW - boxW) / 2
-	if col < 0 {
-		col = 0
-	}
-	row := (screenH - boxH) / 2
-	if row < 0 {
-		row = 0
-	}
-
-	// Normalize the background to exactly screenW×screenH so the box centers
-	// against the real screen rather than the (possibly ragged) content bounds.
-	lines := strings.Split(background, "\n")
-	if len(lines) > screenH {
-		lines = lines[:screenH]
-	}
-	for len(lines) < screenH {
-		lines = append(lines, "")
-	}
-	for i, ln := range lines {
-		lines[i] = lipgloss.PlaceHorizontal(screenW, lipgloss.Left, ln)
-	}
-	background = strings.Join(lines, "\n")
-
-	canvas := lipgloss.NewCompositor(
-		lipgloss.NewLayer(background),
-		lipgloss.NewLayer(box).X(col).Y(row).Z(1),
-	)
-	return canvas.Render()
+	return overlay.Center(background, p.View(), screenW, screenH)
 }

--- a/tui/command_palette_test.go
+++ b/tui/command_palette_test.go
@@ -9,9 +9,8 @@ import (
 )
 
 // TestCommandPaletteRenderKeepsBackgroundOnBoxRows verifies the palette is drawn
-// as a floating layer: background content to the left and right of the box must
-// remain visible on the same rows the box occupies (the whole point of using a
-// canvas instead of blanking full rows).
+// as a floating layer via overlay.Center: background content to the left and
+// right of the box must remain visible on the same rows the box occupies.
 func TestCommandPaletteRenderKeepsBackgroundOnBoxRows(t *testing.T) {
 	const screenW, screenH = 100, 24
 

--- a/tui/folder_inbox.go
+++ b/tui/folder_inbox.go
@@ -593,10 +593,6 @@ func (m *FolderInbox) View() tea.View {
 		content = lipgloss.JoinHorizontal(lipgloss.Top, sidebar, inboxView)
 	}
 
-	// Ensure help bar is always at the very bottom of the total view
-	help := helpStyle.Render(t("folder_inbox.help"))
-	content = lipgloss.JoinVertical(lipgloss.Left, content, help)
-
 	// If move overlay is active, render it on top
 	if m.movingEmail {
 		content = m.renderWithMoveOverlay(content)
@@ -685,9 +681,6 @@ func (m *FolderInbox) renderWithMoveOverlay(content string) string {
 			b.WriteString("\n")
 		}
 	}
-
-	b.WriteString("\n\n")
-	b.WriteString(helpStyle.Render(t("folder_inbox.help")))
 
 	overlay := moveOverlayStyle.Render(b.String())
 


### PR DESCRIPTION
## What?

Uses `bubble-overlay v0.1.0` to simplify the code of the command palette. 

## Why?

This will be reusable in other floating modals.
