### PR TITLE
fix: add row offset for split pane mode

### DIFF
--- a/tui/email_view.go
+++ b/tui/email_view.go
@@ -75,6 +75,7 @@ type EmailView struct {
 	originalICSData    []byte
 	isPreviewMode      bool
 	columnOffset       int // horizontal offset for image rendering in split pane
+	rowOffset          int // vertical offset for image rendering in split pane (vertical layout)
 }
 
 func NewEmailView(email fetcher.Email, emailIndex, width, height int, mailbox MailboxKind, disableImages bool) *EmailView {
@@ -182,12 +183,22 @@ func NewEmailView(email fetcher.Email, emailIndex, width, height int, mailbox Ma
 	}
 }
 
-// NewEmailViewPreview creates EmailView in preview mode with column offset for images
-func NewEmailViewPreview(email fetcher.Email, width, height, colOffset int, disableImages bool) *EmailView {
+// NewEmailViewPreview creates EmailView in preview mode with column and row
+// offsets for out-of-band image rendering. rowOffset is non-zero in vertical
+// split layouts where the preview sits below the inbox pane.
+func NewEmailViewPreview(email fetcher.Email, width, height, colOffset, rowOffset int, disableImages bool) *EmailView {
 	ev := NewEmailView(email, 0, width, height, MailboxInbox, disableImages)
 	ev.isPreviewMode = true
 	ev.columnOffset = colOffset
+	ev.rowOffset = rowOffset
 	return ev
+}
+
+// SetRowOffset updates the vertical offset used for out-of-band image rendering.
+// Call this after a window resize in vertical split mode so images stay aligned
+// with the preview pane's new position.
+func (m *EmailView) SetRowOffset(offset int) {
+	m.rowOffset = offset
 }
 
 func (m *EmailView) Init() tea.Cmd {
@@ -437,7 +448,7 @@ func (m *EmailView) View() tea.View {
 			// always renders from the top-left), so we hide them once
 			// their start line scrolls above the viewport.
 			if p.Line >= yOffset && p.Line < yOffset+vpHeight {
-				screenRow := headerLines + (p.Line - yOffset)
+				screenRow := m.rowOffset + headerLines + (p.Line - yOffset)
 				if m.columnOffset > 0 {
 					view.RenderImageToStdout(p, screenRow, m.columnOffset+1)
 				} else {

--- a/tui/folder_inbox.go
+++ b/tui/folder_inbox.go
@@ -322,6 +322,7 @@ func (m *FolderInbox) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocycl
 				if m.previewPane != nil {
 					previewMsg := tea.WindowSizeMsg{Width: paneWidth, Height: m.calculatePreviewHeight() - 1}
 					m.previewPane.Update(previewMsg)
+					m.previewPane.SetRowOffset(m.calculateInboxHeight() + 1)
 				}
 			} else {
 				inboxWidth := m.calculateInboxWidth()
@@ -416,19 +417,20 @@ func (m *FolderInbox) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocycl
 		email.Body = msg.Body
 		email.BodyMIMEType = msg.BodyMIMEType
 		email.Attachments = msg.Attachments
-		// Create preview pane with column offset for image rendering
+		// Create preview pane with column/row offsets for image rendering.
 		if m.isVerticalSplit() {
 			previewWidth := m.calculateInboxWidthVertical()
 			previewHeight := m.calculatePreviewHeight()
-			// In vertical mode, preview sits below inbox and starts at the same
-			// column offset as the inbox pane.
 			colOffset := sidebarWidth + 2
-			m.previewPane = NewEmailViewPreview(*email, previewWidth, previewHeight, colOffset, m.disableImages)
+			// In vertical split the preview starts below the inbox pane, so
+			// images must be pushed down by the inbox pane height + border row.
+			rowOffset := m.calculateInboxHeight() + 1
+			m.previewPane = NewEmailViewPreview(*email, previewWidth, previewHeight, colOffset, rowOffset, m.disableImages)
 		} else {
 			previewWidth := m.calculatePreviewWidth()
 			inboxWidth := m.calculateInboxWidth()
 			colOffset := sidebarWidth + 2 + inboxWidth + 2 // borders + padding
-			m.previewPane = NewEmailViewPreview(*email, previewWidth, m.height, colOffset, m.disableImages)
+			m.previewPane = NewEmailViewPreview(*email, previewWidth, m.height, colOffset, 0, m.disableImages)
 		}
 		return m, nil
 	}


### PR DESCRIPTION
## What?

Adds a row offset for displaying images in a vertical split pane mode

## Why?

Before:

<img width="2017" height="1250" alt="Screenshot 2026-06-04 at 12 45 50" src="https://github.com/user-attachments/assets/d0a16970-7381-43a2-98d2-0f4a2c727ecb" />


After:

<img width="2017" height="1250" alt="Screenshot 2026-06-04 at 12 45 12" src="https://github.com/user-attachments/assets/e027af5c-9625-4269-9100-53100bd12696" />
