### PR TITLE
ci: use plugins instead of list-plugins

### DIFF
--- a/.github/workflows/bot-check-ci.yml
+++ b/.github/workflows/bot-check-ci.yml
@@ -61,7 +61,7 @@ jobs:
               lint: "Run `make lint` locally.",
               'mod-tidy': "Run `go mod tidy` and commit `go.mod`/`go.sum`.",
               nix: "Run `nix flake check --no-build` locally.",
-              snap: "Validate `snapcraft.yaml` with `snapcraft list-plugins`.",
+              snap: "Validate `snapcraft.yaml` with `snapcraft plugins`.",
               flatpak: "Validate the Flatpak manifest YAML structure.",
               website: "Run `cd docs && npm ci && npx docusaurus build`.",
               'lua-plugins': "Run `luac -p plugins/*.lua` to check Lua syntax.",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           # Verify snapcraft can parse the project file
-          snapcraft list-plugins
+          snapcraft plugins
           # Validate YAML structure and required fields
           python3 << 'PYEOF'
           import yaml, sys


### PR DESCRIPTION
## What?

Uses `plugins` instead of the depreciated `list-plugins`

## Why?

CI failures
