### PR TITLE
feat: custom smtp and imap logins

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,6 +93,11 @@ type Account struct {
 	SMTPPort   int    `json:"smtp_port,omitempty"`
 	Insecure   bool   `json:"insecure,omitempty"`
 
+	// Optional SMTP-specific credentials. When set, these override Email/Password for SMTP auth only.
+	// Useful when the SMTP login differs from the IMAP login (e.g. short username vs full email).
+	SMTPUsername string `json:"smtp_username,omitempty"`
+	SMTPPassword string `json:"-"` // stored in keyring, not JSON
+
 	// S/MIME settings
 	SMIMECert          string `json:"smime_cert,omitempty"`            // Path to the public certificate PEM
 	SMIMEKey           string `json:"smime_key,omitempty"`             // Path to the private key PEM
@@ -320,6 +325,22 @@ func (a *Account) GetSMTPPort() int {
 	}
 }
 
+// GetSMTPUsername returns the SMTP login username, falling back to Email when not set.
+func (a *Account) GetSMTPUsername() string {
+	if a.SMTPUsername != "" {
+		return a.SMTPUsername
+	}
+	return a.Email
+}
+
+// GetSMTPPassword returns the SMTP password, falling back to Password when not set.
+func (a *Account) GetSMTPPassword() string {
+	if a.SMTPPassword != "" {
+		return a.SMTPPassword
+	}
+	return a.Password
+}
+
 // GetFetchEmail returns the configured fetch identity, falling back to Email.
 func (a *Account) GetFetchEmail() string {
 	if a.FetchEmail != "" {
@@ -460,6 +481,8 @@ type secureDiskAccount struct {
 	SMTPServer         string `json:"smtp_server,omitempty"`
 	SMTPPort           int    `json:"smtp_port,omitempty"`
 	Insecure           bool   `json:"insecure,omitempty"`
+	SMTPUsername       string `json:"smtp_username,omitempty"`
+	SMTPPassword       string `json:"smtp_password,omitempty"`
 	SMIMECert          string `json:"smime_cert,omitempty"`
 	SMIMEKey           string `json:"smime_key,omitempty"`
 	SMIMESignByDefault bool   `json:"smime_sign_by_default,omitempty"`
@@ -512,6 +535,11 @@ func SaveConfig(config *Config) error {
 			if acc.Password != "" && acc.PassCmd == "" {
 				if err := keyring.Set(keyringServiceName, acc.Email, acc.Password); err != nil {
 					log.Printf("matcha: failed to store password for %s in keyring: %v", acc.Email, err)
+				}
+			}
+			if acc.SMTPPassword != "" && acc.PassCmd == "" {
+				if err := keyring.Set(keyringServiceName, acc.Email+":smtp-password", acc.SMTPPassword); err != nil {
+					log.Printf("matcha: failed to store SMTP password for %s in keyring: %v", acc.Email, err)
 				}
 			}
 			if acc.PGPPIN != "" && acc.PGPKeySource == "yubikey" {
@@ -568,6 +596,8 @@ func SaveConfig(config *Config) error {
 				SMTPServer:         acc.SMTPServer,
 				SMTPPort:           acc.SMTPPort,
 				Insecure:           acc.Insecure,
+				SMTPUsername:       acc.SMTPUsername,
+				SMTPPassword:       acc.SMTPPassword,
 				SMIMECert:          acc.SMIMECert,
 				SMIMEKey:           acc.SMIMEKey,
 				SMIMESignByDefault: acc.SMIMESignByDefault,
@@ -632,6 +662,8 @@ func LoadConfig() (*Config, error) {
 		SMTPServer         string `json:"smtp_server,omitempty"`
 		SMTPPort           int    `json:"smtp_port,omitempty"`
 		Insecure           bool   `json:"insecure,omitempty"`
+		SMTPUsername       string `json:"smtp_username,omitempty"`
+		SMTPPassword       string `json:"smtp_password,omitempty"`
 		SMIMECert          string `json:"smime_cert,omitempty"`
 		SMIMEKey           string `json:"smime_key,omitempty"`
 		SMIMESignByDefault bool   `json:"smime_sign_by_default,omitempty"`
@@ -731,6 +763,7 @@ func LoadConfig() (*Config, error) {
 			SMTPServer:         rawAcc.SMTPServer,
 			SMTPPort:           rawAcc.SMTPPort,
 			Insecure:           rawAcc.Insecure,
+			SMTPUsername:       rawAcc.SMTPUsername,
 			SMIMECert:          rawAcc.SMIMECert,
 			SMIMEKey:           rawAcc.SMIMEKey,
 			SMIMESignByDefault: rawAcc.SMIMESignByDefault,
@@ -766,6 +799,7 @@ func LoadConfig() (*Config, error) {
 			// In secure mode, passwords and PINs are stored in the encrypted config JSON
 			acc.Password = rawAcc.Password
 			acc.PGPPIN = rawAcc.PGPPIN
+			acc.SMTPPassword = rawAcc.SMTPPassword
 		case rawAcc.Password != "":
 			// Found a plain-text password! Move it to the OS Keyring.
 			if err := keyring.Set(keyringServiceName, rawAcc.Email, rawAcc.Password); err != nil {
@@ -785,6 +819,12 @@ func LoadConfig() (*Config, error) {
 			if acc.PGPKeySource == "yubikey" {
 				if pin, err := keyring.Get(keyringServiceName, acc.Email+":pgp-pin"); err == nil {
 					acc.PGPPIN = pin
+				}
+			}
+			// Load SMTP-specific password from keyring if smtp_username is set
+			if acc.SMTPUsername != "" {
+				if smtpPwd, err := keyring.Get(keyringServiceName, acc.Email+":smtp-password"); err == nil {
+					acc.SMTPPassword = smtpPwd
 				}
 			}
 		}

--- a/docs/docs/Configuration.md
+++ b/docs/docs/Configuration.md
@@ -33,7 +33,8 @@ Configuration is stored in `~/.config/matcha/config.json`.
       "imap_server": "imap.company.com",
       "imap_port": 993,
       "smtp_server": "smtp.company.com",
-      "smtp_port": 587
+      "smtp_port": 587,
+      "smtp_username": "jdoe"
     }
   ],
   "mailing_lists": [
@@ -56,6 +57,8 @@ Configuration is stored in `~/.config/matcha/config.json`.
 ```
 
 `send_as_email` is optional. When set, Matcha uses it for the outgoing `From` header while continuing to authenticate with the account's login address.
+
+`smtp_username` is optional. When set, Matcha uses it instead of `email` when authenticating with the SMTP server. Set this when your mail provider uses different credentials for IMAP and SMTP — for example, a full email address for IMAP but a short username for SMTP. The corresponding SMTP password is stored separately in the OS keyring under the key `<email>:smtp-password`; if no SMTP-specific password is stored, the main account password is used as a fallback.
 
 `enable_split_pane` enables a side-by-side view where the email list and the selected email are shown on the same screen.
 

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -205,8 +205,10 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 		return nil, fmt.Errorf("unsupported or missing service_provider: %s", account.ServiceProvider)
 	}
 
-	plainAuth := smtp.PlainAuth("", account.Email, account.Password, smtpServer)
-	loginAuthFallback := &loginAuth{username: account.Email, password: account.Password}
+	smtpUser := account.GetSMTPUsername()
+	smtpPass := account.GetSMTPPassword()
+	plainAuth := smtp.PlainAuth("", smtpUser, smtpPass, smtpServer)
+	loginAuthFallback := &loginAuth{username: smtpUser, password: smtpPass}
 
 	fromHeader := account.FormatFromHeader()
 
@@ -787,8 +789,10 @@ func SendCalendarReply(account *config.Account, to []string, subject, plainBody 
 		return nil, fmt.Errorf("unsupported or missing service_provider: %s", account.ServiceProvider)
 	}
 
-	plainAuth := smtp.PlainAuth("", account.Email, account.Password, smtpServer)
-	loginAuthFallback := &loginAuth{username: account.Email, password: account.Password}
+	smtpUser := account.GetSMTPUsername()
+	smtpPass := account.GetSMTPPassword()
+	plainAuth := smtp.PlainAuth("", smtpUser, smtpPass, smtpServer)
+	loginAuthFallback := &loginAuth{username: smtpUser, password: smtpPass}
 
 	fromHeader := account.FormatFromHeader()
 


### PR DESCRIPTION
## What?

Adds custom config fields to set separate logins for SMTP and IMAP.

## Why?

Requested in #1312 
