### PR TITLE
fix(tui): sync unread badge on delete

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,6 +145,9 @@ type mainModel struct {
 	sendNotice    string
 	pendingAction *pendingEmailAction
 	actionNotice  string
+	// unreadBadge caches the unread count last pushed to the OS badge so the
+	// value the badge derives from is observable after email operations.
+	unreadBadge int
 }
 
 type logEntryMsg struct {
@@ -296,10 +299,11 @@ func unreadBadgeCount(emailsByAcct, folderEmails map[string][]fetcher.Email) int
 }
 
 func (m *mainModel) syncUnreadBadge() {
+	count := unreadBadgeCount(m.emailsByAcct, m.folderEmails)
+	m.unreadBadge = count
 	if runtime.GOOS != goosDarwin && loglevel.Get() < loglevel.LevelDebug {
 		return
 	}
-	count := unreadBadgeCount(m.emailsByAcct, m.folderEmails)
 	loglevel.Debugf("unread badge count: %d", count)
 	if runtime.GOOS != goosDarwin {
 		return
@@ -1936,6 +1940,8 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 			go saveFolderEmailsToCache(folderName, filtered)
 		}
 
+		m.syncUnreadBadge()
+
 		pa := &pendingEmailAction{
 			jobID:      fmt.Sprintf("action-%d", time.Now().UnixNano()),
 			kind:       actionKindDelete,
@@ -1985,6 +1991,8 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 			m.folderEmails[folderName] = filtered
 			go saveFolderEmailsToCache(folderName, filtered)
 		}
+
+		m.syncUnreadBadge()
 
 		pa := &pendingEmailAction{
 			jobID:      fmt.Sprintf("action-%d", time.Now().UnixNano()),
@@ -2065,6 +2073,8 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 			go saveFolderEmailsToCache(folderName, filtered)
 		}
 
+		m.syncUnreadBadge()
+
 		pa := &pendingEmailAction{
 			jobID:      fmt.Sprintf("action-%d", time.Now().UnixNano()),
 			kind:       actionKindDelete,
@@ -2118,6 +2128,8 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 			m.folderEmails[folderName] = filtered
 			go saveFolderEmailsToCache(folderName, filtered)
 		}
+
+		m.syncUnreadBadge()
 
 		pa := &pendingEmailAction{
 			jobID:      fmt.Sprintf("action-%d", time.Now().UnixNano()),

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/floatpane/matcha/config"
 	"github.com/floatpane/matcha/fetcher"
+	"github.com/floatpane/matcha/tui"
 )
 
 func TestSanitizeFilenameTruncatesCJKOnUTF8Boundary(t *testing.T) {
@@ -58,6 +60,81 @@ func TestParseGlobalFlagsDoesNotConsumeSubcommandFlags(t *testing.T) {
 	}
 	if got := strings.Join(args, " "); got != "matcha send --logs" {
 		t.Fatalf("args = %q, want %q", got, "matcha send --logs")
+	}
+}
+
+// newBadgeTestModel builds a minimal mainModel seeded with a single unread
+// email for one account, ready to receive delete/archive messages.
+func newBadgeTestModel(uid uint32, accountID string) *mainModel {
+	email := fetcher.Email{UID: uid, AccountID: accountID, IsRead: false}
+	return &mainModel{
+		current: tui.NewChoice(),
+		config: &config.Config{
+			Accounts: []config.Account{{ID: accountID}},
+		},
+		emails:       []fetcher.Email{email},
+		emailsByAcct: map[string][]fetcher.Email{accountID: {email}},
+		folderEmails: map[string][]fetcher.Email{folderInbox: {email}},
+	}
+}
+
+func TestDeleteEmailRefreshesUnreadBadge(t *testing.T) {
+	const acct = "acct-a"
+	m := newBadgeTestModel(7, acct)
+	m.syncUnreadBadge()
+	if m.unreadBadge != 1 {
+		t.Fatalf("setup: unreadBadge = %d, want 1", m.unreadBadge)
+	}
+
+	m.Update(tui.DeleteEmailMsg{UID: 7, AccountID: acct})
+
+	if m.unreadBadge != 0 {
+		t.Fatalf("after delete: unreadBadge = %d, want 0 (badge not refreshed)", m.unreadBadge)
+	}
+}
+
+func TestArchiveEmailRefreshesUnreadBadge(t *testing.T) {
+	const acct = "acct-a"
+	m := newBadgeTestModel(7, acct)
+	m.syncUnreadBadge()
+	if m.unreadBadge != 1 {
+		t.Fatalf("setup: unreadBadge = %d, want 1", m.unreadBadge)
+	}
+
+	m.Update(tui.ArchiveEmailMsg{UID: 7, AccountID: acct})
+
+	if m.unreadBadge != 0 {
+		t.Fatalf("after archive: unreadBadge = %d, want 0 (badge not refreshed)", m.unreadBadge)
+	}
+}
+
+func TestBatchDeleteEmailsRefreshesUnreadBadge(t *testing.T) {
+	const acct = "acct-a"
+	m := newBadgeTestModel(7, acct)
+	m.syncUnreadBadge()
+	if m.unreadBadge != 1 {
+		t.Fatalf("setup: unreadBadge = %d, want 1", m.unreadBadge)
+	}
+
+	m.Update(tui.BatchDeleteEmailsMsg{UIDs: []uint32{7}, AccountID: acct})
+
+	if m.unreadBadge != 0 {
+		t.Fatalf("after batch delete: unreadBadge = %d, want 0 (badge not refreshed)", m.unreadBadge)
+	}
+}
+
+func TestBatchArchiveEmailsRefreshesUnreadBadge(t *testing.T) {
+	const acct = "acct-a"
+	m := newBadgeTestModel(7, acct)
+	m.syncUnreadBadge()
+	if m.unreadBadge != 1 {
+		t.Fatalf("setup: unreadBadge = %d, want 1", m.unreadBadge)
+	}
+
+	m.Update(tui.BatchArchiveEmailsMsg{UIDs: []uint32{7}, AccountID: acct})
+
+	if m.unreadBadge != 0 {
+		t.Fatalf("after batch archive: unreadBadge = %d, want 0 (badge not refreshed)", m.unreadBadge)
 	}
 }
 


### PR DESCRIPTION
## What?

After deleting or archiving emails, the delete/archive `Update` handlers (`DeleteEmailMsg`, `ArchiveEmailMsg`, `BatchDeleteEmailsMsg`, `BatchArchiveEmailsMsg`) now call `m.syncUnreadBadge()`, mirroring the read/unread handlers, so the unread badge recomputes immediately. `syncUnreadBadge` also caches the count on every OS so the behavior is unit-testable. Adds four tests asserting the macOS badge drops to 0 after the last unread email is deleted/archived.

## Why?

The delete/archive handlers mutated the unread stores but never recomputed the unread menu bar badge, so the counter only refreshed on the next fetch.


