### PR TITLE
feat: open HTML emails in browser

### DIFF
--- a/config/default_keybinds.json
+++ b/config/default_keybinds.json
@@ -26,7 +26,8 @@
     "rsvp_accept": "1",
     "rsvp_decline": "2",
     "rsvp_tentative": "3",
-    "focus_attachments": "tab"
+    "focus_attachments": "tab",
+    "open_html_browser": "o"
   },
   "composer": {
     "external_editor": "ctrl+e",

--- a/config/keybinds.go
+++ b/config/keybinds.go
@@ -56,6 +56,7 @@ type EmailKeys struct {
 	RsvpDecline      string `json:"rsvp_decline"`
 	RsvpTentative    string `json:"rsvp_tentative"`
 	FocusAttachments string `json:"focus_attachments"`
+	OpenHTMLBrowser  string `json:"open_html_browser"`
 }
 
 type ComposerKeys struct {

--- a/main.go
+++ b/main.go
@@ -1707,7 +1707,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 		return m, m.current.Init()
 
 	case tui.OpenHTMLEmailMsg:
-			return m, openHTMLInBrowser(msg.Email.Body)
+		return m, openHTMLInBrowser(msg.Email.Body)
 	case tui.OpenEditorMsg:
 		composer, ok := m.current.(*tui.Composer)
 		if !ok {

--- a/main.go
+++ b/main.go
@@ -1706,6 +1706,8 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 		m.syncPluginKeyBindings()
 		return m, m.current.Init()
 
+	case tui.OpenHTMLEmailMsg:
+			return m, openHTMLInBrowser(msg.Email.Body)
 	case tui.OpenEditorMsg:
 		composer, ok := m.current.(*tui.Composer)
 		if !ok {
@@ -3163,6 +3165,57 @@ func openExternalEditor(body string) tea.Cmd {
 		}
 		return tui.EditorFinishedMsg{Body: string(content)}
 	})
+}
+
+// openHTMLInBrowser writes the HTML body to a temp file and opens it in the default browser.
+func openHTMLInBrowser(htmlBody string) tea.Cmd {
+	return func() tea.Msg {
+		tmpFile, err := os.CreateTemp("", "matcha-*.html")
+		if err != nil {
+			return nil
+		}
+		tmpPath := tmpFile.Name()
+
+		if _, err := tmpFile.WriteString(htmlBody); err != nil {
+			_ = tmpFile.Close()
+			_ = os.Remove(tmpPath)
+			return nil
+		}
+		if err := tmpFile.Close(); err != nil {
+			_ = os.Remove(tmpPath)
+			return nil
+		}
+
+		// Determine the command to open the browser based on the OS
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		var cmd *exec.Cmd
+		switch runtime.GOOS {
+		case goosDarwin: // macOS
+			cmd = exec.CommandContext(ctx, "open", tmpPath) //nolint:gosec
+		case "linux":
+			cmd = exec.CommandContext(ctx, "xdg-open", tmpPath) //nolint:gosec
+		case "windows":
+			cmd = exec.CommandContext(ctx, "cmd", "/c", "start", tmpPath) //nolint:gosec
+		default:
+			_ = os.Remove(tmpPath)
+			return nil
+		}
+
+		// Run the command asynchronously without waiting for it to complete
+		// so the temp file isn't deleted before the browser opens it
+		if err := cmd.Start(); err != nil {
+			_ = os.Remove(tmpPath)
+			return nil
+		}
+
+		// Schedule cleanup of the temp file after a delay to allow the browser to read it
+		time.AfterFunc(30*time.Second, func() {
+			_ = os.Remove(tmpPath)
+		})
+
+		return nil
+	}
 }
 
 // --- IDLE command ---

--- a/main.go
+++ b/main.go
@@ -3192,11 +3192,11 @@ func openHTMLInBrowser(htmlBody string) tea.Cmd {
 		var cmd *exec.Cmd
 		switch runtime.GOOS {
 		case goosDarwin: // macOS
-			cmd = exec.CommandContext(ctx, "open", tmpPath) //nolint:gosec
+			cmd = exec.CommandContext(ctx, "open", tmpPath)
 		case "linux":
-			cmd = exec.CommandContext(ctx, "xdg-open", tmpPath) //nolint:gosec
+			cmd = exec.CommandContext(ctx, "xdg-open", tmpPath)
 		case "windows":
-			cmd = exec.CommandContext(ctx, "cmd", "/c", "start", tmpPath) //nolint:gosec
+			cmd = exec.CommandContext(ctx, "cmd", "/c", "start", tmpPath)
 		default:
 			_ = os.Remove(tmpPath)
 			return nil

--- a/tui/email_view.go
+++ b/tui/email_view.go
@@ -194,7 +194,7 @@ func (m *EmailView) Init() tea.Cmd {
 	return nil
 }
 
-func (m *EmailView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *EmailView) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 	var cmd tea.Cmd
 	cmds := make([]tea.Cmd, 0, 1)
 
@@ -312,6 +312,12 @@ func (m *EmailView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if len(m.email.Attachments) > 0 {
 					m.focusOnAttachments = true
 				}
+			case kb.Email.OpenHTMLBrowser:
+				if m.email.BodyMIMEType == "text/html" && len(m.email.Body) > 0 {
+					// Clear Kitty graphics before opening browser
+					ClearKittyGraphics()
+					return m, func() tea.Msg { return OpenHTMLEmailMsg{Email: m.email} }
+				}
 			}
 		}
 	case tea.WindowSizeMsg:
@@ -386,8 +392,11 @@ func (m *EmailView) View() tea.View {
 	} else {
 		var shortcuts strings.Builder
 		shortcuts.WriteString("\uf112 r: reply • \uf064 f: forward • \uea81 d: delete • \uea98 a: archive • \uf435 tab: focus attachments • \ueb06 esc: back to inbox")
+		if m.email.BodyMIMEType == "text/html" && len(m.email.Body) > 0 {
+			shortcuts.WriteString(" • \uf303 o: open in browser")
+		}
 		if view.ImageProtocolSupported() {
-			shortcuts.WriteString("• \uf03e i: toggle images")
+			shortcuts.WriteString(" • \uf03e i: toggle images")
 		}
 		for _, pk := range m.pluginKeyBindings {
 			shortcuts.WriteString(" • ")

--- a/tui/messages.go
+++ b/tui/messages.go
@@ -184,6 +184,10 @@ type ForwardEmailMsg struct {
 	Email fetcher.Email
 }
 
+type OpenHTMLEmailMsg struct {
+	Email fetcher.Email
+}
+
 type SetComposerCursorToStartMsg struct{}
 
 type GoToFilePickerMsg struct{}


### PR DESCRIPTION
## What?

Added a new action to open HTML emails in the default browser. When viewing an HTML email, users can now press `o` to write the HTML body to a temporary file and open it in their system's default browser (using `open` on macOS, `xdg-open` on Linux, and `cmd /c start` on Windows).

**Changes:**
- Added `OpenHTMLBrowser` keybinding (default: `o`) to `config/keybinds.go` and `config/default_keybinds.json`
- Added `OpenHTMLEmailMsg` message type to `tui/messages.go`
- Updated `tui/email_view.go` to emit the message when pressing `o` on HTML emails, with updated help text
- Implemented `openHTMLInBrowser()` function in `main.go` that creates a temp HTML file and opens it with the system browser
- Schedules automatic cleanup of temp files after 30 seconds

## Why?

Complex HTML emails are hard to read in the terminal's degraded text rendering. Opening them in a real browser makes them much easier to view with proper formatting, images, and styling intact. This is a beginner-friendly feature that solves the original issue of poor HTML email readability in TUI mode.

Fixes: #1150 
