### PR TITLE
feat: PGP key look up via WKD

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GOTOOLCHAIN: auto
         with:
-          args: "-no-fail -fmt=sarif -out=gosec.sarif -severity=medium -confidence=medium -exclude=G101,G115,G204,G304,G306,G401,G501,G702,G703 ./..."
+          args: "-no-fail -fmt=sarif -out=gosec.sarif -severity=medium -confidence=medium -exclude=G101,G115,G204,G304,G306,G401,G501,G505,G702,G703 ./..."
 
       - name: Upload SARIF
         if: always() && hashFiles('gosec.sarif') != ''

--- a/docs/docs/Features/PGP.md
+++ b/docs/docs/Features/PGP.md
@@ -8,6 +8,7 @@ Matcha supports PGP (Pretty Good Privacy) for signing and encrypting your emails
 - **Encryption**: Encrypt emails so only the intended recipients can read them.
 - **Signature Verification**: Automatically verify PGP signatures on incoming emails.
 - **Encrypted Email Decryption**: Decrypt incoming PGP-encrypted emails using your private key.
+- **WKD Key Discovery**: Automatically look up recipient and sender public keys via the Web Key Directory (WKD) protocol.
 - **Per-Account Configuration**: Configure separate keys for each email account.
 - **Sign by Default**: Optionally enable automatic signing for all outgoing emails.
 - **Encrypt by Default**: Optionally encrypt all outgoing emails when recipient keys are available.
@@ -95,11 +96,65 @@ For example, to encrypt an email to `alice@example.com`, place her public key at
 ```
 
 You can obtain someone's public key from:
+- **WKD (automatic)**: Matcha looks up keys via the Web Key Directory when encrypting or verifying (see below)
 - A keyserver: `gpg --recv-keys <key-id> && gpg --export --armor alice@example.com > ~/.config/matcha/pgp/alice@example.com.asc`
 - Their website or email signature
 - Direct exchange
 
 Matcha automatically includes your own public key when encrypting, so you can still read the email in your Sent folder.
+
+### Automatic Key Discovery (WKD)
+
+Matcha supports the [Web Key Directory (WKD)](https://datatracker.ietf.org/doc/draft-koch-openpgp-webkey-service/) protocol for automatic PGP public key discovery. WKD allows domains to publish their users' public keys at a well-known HTTPS endpoint.
+
+#### How It Works
+
+When Matcha needs a recipient's or sender's public key and no local key file exists, it:
+
+1. Constructs the WKD URL from the email address (e.g., `https://example.com/.well-known/openpgpkey/hu/<hash>?l=alice`)
+2. Fetches the public key over HTTPS
+3. Caches the key locally in `~/.config/matcha/pgp/<email>.asc` for future use
+
+#### Encryption
+
+When you enable PGP encryption in the composer, Matcha checks whether all recipient keys are available locally. If any are missing, a confirmation dialog lists the recipients and asks whether to download their keys via WKD:
+
+```
+Missing PGP keys for:
+
+  • alice@example.com
+  • bob@example.org
+
+Download from WKD?
+
+(y/n)
+```
+
+Press `y` to download and cache the keys, which also enables encryption. Press `n` to cancel. Keys that cannot be found via WKD will be reported in a notification.
+
+#### Signature Verification
+
+When viewing an incoming email with a PGP signature that could not be verified (the sender's key is not in your local keyring), Matcha automatically attempts a WKD lookup for the sender's domain. If the key is found, the signature is re-verified and the key is cached for future emails from that sender.
+
+This means the first time you open a signed email from a WKD-enabled domain, it may briefly show as "Unverified" before updating to "Verified" on subsequent views.
+
+#### Supported Domains
+
+WKD works with any domain that publishes keys at the standard well-known path. Major providers with WKD support include:
+
+- `proton.me` / `protonmail.com`
+- `posteo.de`
+- `mailbox.org`
+- Many corporate and university domains
+
+You can check if a domain supports WKD by visiting `https://<domain>/.well-known/openpgpkey/` in a browser.
+
+#### Privacy Considerations
+
+- WKD lookups are performed over HTTPS, so the key content is encrypted in transit
+- The lookup reveals to the domain operator that someone requested a specific user's key
+- Cached keys are stored locally and reused, minimizing repeat lookups
+- No third-party keyservers are contacted — only the recipient's own domain
 
 ### Supported Key Formats
 
@@ -247,7 +302,7 @@ Matcha supports both PGP and S/MIME. They are mutually exclusive per message: yo
 
 | | PGP | S/MIME |
 |---|-----|--------|
-| **Key management** | Manual (keyservers, direct exchange) | Certificate Authorities |
+| **Key management** | Automatic (WKD) or manual (keyservers, direct exchange) | Certificate Authorities |
 | **Trust model** | Web of Trust / TOFU | Hierarchical (CA-based) |
 | **Popular with** | Open-source, privacy communities | Enterprise, corporate |
 | **Hardware keys** | YubiKey, smartcards | Smart cards, USB tokens |
@@ -376,7 +431,7 @@ gpg --show-keys ~/.config/matcha/pgp/private.asc
 
 ### Signature shows as "Unverified"
 
-This happens when the sender's public key is not available to verify the signature. To verify signatures from a contact, store their public key at:
+This happens when the sender's public key is not available to verify the signature. Matcha will automatically attempt to fetch the key via WKD on first view. If the sender's domain does not support WKD, you can manually store their public key at:
 
 ```
 ~/.config/matcha/pgp/<sender-email>.asc

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -737,6 +737,7 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 
 	fetchCmd := c.Fetch(uidSet, &imap.FetchOptions{
 		BodyStructure: &imap.FetchItemBodyStructure{Extended: true},
+		Envelope:      true,
 	})
 	bsMsgs, err := fetchCmd.Collect()
 	if err != nil {
@@ -748,6 +749,11 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 	}
 
 	msg := bsMsgs[0]
+
+	var senderEmail string
+	if msg.Envelope != nil && len(msg.Envelope.From) > 0 {
+		senderEmail = msg.Envelope.From[0].Addr()
+	}
 
 	var plainPartID, plainPartEncoding string
 	var htmlPartID, htmlPartEncoding string
@@ -1160,7 +1166,7 @@ func FetchEmailBodyFromMailbox(account *config.Account, mailbox string, uid uint
 								signedData := rawEmail[startIdx:endIdx]
 
 								// Verify PGP signature
-								verified := verifyPGPSignature(signedData, data, account)
+								verified := verifyPGPSignature(signedData, data, account, senderEmail)
 								att.PGPVerified = verified
 							}
 						}
@@ -2149,13 +2155,41 @@ func loadPGPKeyring(account *config.Account) openpgp.EntityList {
 }
 
 // verifyPGPSignature verifies a PGP detached signature against signed content.
-func verifyPGPSignature(signedContent, signatureData []byte, account *config.Account) bool {
+// When local keyring verification fails and senderEmail is non-empty, it
+// attempts a WKD lookup for the sender's key and retries.
+func verifyPGPSignature(signedContent, signatureData []byte, account *config.Account, senderEmail string) bool {
 	keyring := loadPGPKeyring(account)
+	if len(keyring) == 0 && senderEmail == "" {
+		return false
+	}
+
+	if verifyWithKeyringLocal(signedContent, signatureData, keyring) {
+		return true
+	}
+
+	if senderEmail == "" {
+		return false
+	}
+
+	entity, err := pgp.LookupWKD(senderEmail)
+	if err != nil {
+		return false
+	}
+
+	cfgDir, err := config.GetConfigDir()
+	if err == nil {
+		_ = pgp.CacheWKDKey(cfgDir+"/pgp", senderEmail, entity)
+	}
+
+	keyring = append(keyring, entity)
+	return verifyWithKeyringLocal(signedContent, signatureData, keyring)
+}
+
+func verifyWithKeyringLocal(signedContent, signatureData []byte, keyring openpgp.EntityList) bool {
 	if len(keyring) == 0 {
 		return false
 	}
 
-	// Build a complete multipart/signed message for go-pgpmail
 	boundary := "pgp-verify-boundary"
 	var msg bytes.Buffer
 	msg.WriteString("Content-Type: multipart/signed; boundary=\"" + boundary + "\"; micalg=pgp-sha256; protocol=\"application/pgp-signature\"\r\n\r\n")
@@ -2175,7 +2209,6 @@ func verifyPGPSignature(signedContent, signatureData []byte, account *config.Acc
 		return false
 	}
 
-	// Must read UnverifiedBody to EOF to trigger signature verification
 	_, _ = io.ReadAll(mr.MessageDetails.UnverifiedBody)
 
 	return mr.MessageDetails.SignatureError == nil

--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -26,6 +26,8 @@ const (
 	IMAPBatchActionTimeout = 60 * time.Second
 	// IMAPSearchTimeout bounds server-side IMAP search queries from main (main.go).
 	IMAPSearchTimeout = 60 * time.Second
+	// WKDLookupTimeout bounds Web Key Directory lookups for PGP public keys (pgp/wkd.go).
+	WKDLookupTimeout = 10 * time.Second
 )
 
 // New returns an http.Client preconfigured with the given timeout.

--- a/pgp/file.go
+++ b/pgp/file.go
@@ -155,7 +155,7 @@ func (p *FileBasedProvider) VerifyWithSender(signedContent, signatureData []byte
 
 	entity, wkdErr := LookupWKD(email)
 	if wkdErr != nil {
-		return PGPStatusUnverified, nil
+		return PGPStatusUnverified, wkdErr
 	}
 
 	if cacheErr := CacheWKDKey(p.pgpDir, email, entity); cacheErr != nil {

--- a/pgp/file.go
+++ b/pgp/file.go
@@ -134,7 +134,43 @@ func (p *FileBasedProvider) Verify(signedContent, signatureData []byte) (PGPStat
 		return PGPStatusUnverified, nil
 	}
 
-	// Reconstruct a minimal multipart/signed message for pgpmail.Read.
+	return verifyWithKeyring(signedContent, signatureData, keyring)
+}
+
+// VerifyWithSender attempts to verify a PGP signature, falling back to WKD
+// lookup for the sender's key when the local keyring doesn't contain it.
+// If WKD succeeds, the key is cached locally for future use.
+func (p *FileBasedProvider) VerifyWithSender(signedContent, signatureData []byte, senderEmail string) (PGPStatus, error) {
+	keyring := p.loadPublicKeyring()
+
+	status, err := verifyWithKeyring(signedContent, signatureData, keyring)
+	if status == PGPStatusVerified {
+		return status, err
+	}
+
+	email := extractEmail(senderEmail)
+	if email == "" {
+		return PGPStatusUnverified, nil
+	}
+
+	entity, wkdErr := LookupWKD(email)
+	if wkdErr != nil {
+		return PGPStatusUnverified, nil
+	}
+
+	if cacheErr := CacheWKDKey(p.pgpDir, email, entity); cacheErr != nil {
+		_ = cacheErr
+	}
+
+	keyring = append(keyring, entity)
+	return verifyWithKeyring(signedContent, signatureData, keyring)
+}
+
+func verifyWithKeyring(signedContent, signatureData []byte, keyring openpgp.EntityList) (PGPStatus, error) {
+	if len(keyring) == 0 {
+		return PGPStatusUnverified, nil
+	}
+
 	const boundary = "pgp-verify-boundary"
 	var msg bytes.Buffer
 	msg.WriteString("Content-Type: multipart/signed; boundary=\"" + boundary + "\"; " +
@@ -150,7 +186,6 @@ func (p *FileBasedProvider) Verify(signedContent, signatureData []byte) (PGPStat
 	if mr == nil || mr.MessageDetails == nil || mr.MessageDetails.UnverifiedBody == nil {
 		return PGPStatusUnverified, nil
 	}
-	// Must drain UnverifiedBody to EOF to trigger signature verification.
 	_, _ = io.ReadAll(mr.MessageDetails.UnverifiedBody)
 	if mr.MessageDetails.SignatureError != nil {
 		return PGPStatusUnverified, mr.MessageDetails.SignatureError
@@ -221,7 +256,17 @@ func (p *FileBasedProvider) loadPublicKeyForEmail(email string) (*openpgp.Entity
 			return entity, nil
 		}
 	}
-	return nil, fmt.Errorf("no key file found in %s for %s", p.pgpDir, email)
+
+	entity, err := LookupWKD(email)
+	if err != nil {
+		return nil, fmt.Errorf("no key file found in %s for %s and WKD lookup failed: %w", p.pgpDir, email, err)
+	}
+
+	if cacheErr := CacheWKDKey(p.pgpDir, email, entity); cacheErr != nil {
+		// Non-fatal: we have the key even if caching fails.
+		_ = cacheErr
+	}
+	return entity, nil
 }
 
 func (p *FileBasedProvider) loadPublicKeyring() openpgp.EntityList {

--- a/pgp/wkd.go
+++ b/pgp/wkd.go
@@ -1,0 +1,128 @@
+package pgp
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/base32"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/floatpane/matcha/internal/httpclient"
+)
+
+// wkdDirectURL builds the "direct" WKD URL for an email address.
+// See https://datatracker.ietf.org/doc/draft-koch-openpgp-webkey-service/
+//
+// The direct method uses:
+//
+//	https://<domain>/.well-known/openpgpkey/hu/<z-base-32-hash>?l=<local-part>
+func wkdDirectURL(email string) (string, error) {
+	local, domain, ok := strings.Cut(strings.ToLower(strings.TrimSpace(email)), "@")
+	if !ok || local == "" || domain == "" {
+		return "", fmt.Errorf("wkd: invalid email %q", email)
+	}
+
+	h := sha1.Sum([]byte(local))
+	hash := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(h[:]))
+
+	return fmt.Sprintf("https://%s/.well-known/openpgpkey/hu/%s?l=%s", domain, hash, local), nil
+}
+
+// LookupWKD attempts to fetch a PGP public key via the Web Key Directory
+// protocol for the given email address. Returns the parsed OpenPGP entity on
+// success. On any failure (network, parsing, no key published) it returns an
+// error and does NOT cache anything to disk.
+func LookupWKD(email string) (*openpgp.Entity, error) {
+	url, err := wkdDirectURL(email)
+	if err != nil {
+		return nil, err
+	}
+
+	client := httpclient.New(httpclient.WKDLookupTimeout)
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("wkd: fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("wkd: %s returned status %d", url, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // cap at 1 MiB
+	if err != nil {
+		return nil, fmt.Errorf("wkd: read response: %w", err)
+	}
+
+	entityList, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(body))
+	if err != nil {
+		entityList, err = openpgp.ReadKeyRing(bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("wkd: parse key: %w", err)
+		}
+	}
+	if len(entityList) == 0 {
+		return nil, fmt.Errorf("wkd: no keys in response from %s", url)
+	}
+	return entityList[0], nil
+}
+
+// CacheWKDKey saves an armored public key to the pgp directory so subsequent
+// lookups hit disk instead of the network. The file is stored as <email>.asc.
+func CacheWKDKey(pgpDir, email string, entity *openpgp.Entity) error {
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		return fmt.Errorf("wkd: armor encode: %w", err)
+	}
+	if err := entity.Serialize(w); err != nil {
+		return fmt.Errorf("wkd: serialize: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("wkd: armor close: %w", err)
+	}
+
+	if err := os.MkdirAll(pgpDir, 0700); err != nil {
+		return fmt.Errorf("wkd: mkdir: %w", err)
+	}
+
+	path := filepath.Join(pgpDir, strings.ToLower(strings.TrimSpace(email))+".asc")
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("wkd: write cache: %w", err)
+	}
+	return nil
+}
+
+// MissingLocalKeys returns the subset of recipient emails that don't have a
+// public key file in pgpDir. Used by the composer to decide whether to prompt
+// for WKD download before enabling encryption.
+func MissingLocalKeys(pgpDir string, recipients []string) []string {
+	var missing []string
+	for _, r := range recipients {
+		email := strings.ToLower(strings.TrimSpace(r))
+		if i := strings.Index(email, "<"); i >= 0 {
+			email = strings.TrimSuffix(email[i+1:], ">")
+		}
+		email = strings.TrimSpace(email)
+		if email == "" {
+			continue
+		}
+		found := false
+		for _, ext := range []string{".asc", ".gpg", ".pem"} {
+			if _, err := os.Stat(filepath.Join(pgpDir, email+ext)); err == nil {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, email)
+		}
+	}
+	return missing
+}

--- a/pgp/wkd.go
+++ b/pgp/wkd.go
@@ -3,7 +3,7 @@ package pgp
 import (
 	"bytes"
 	"context"
-	crypto_sha1 "crypto/sha1" //nolint:gosec // SHA-1 is mandated by the WKD spec (draft-koch-openpgp-webkey-service)
+	crypto_sha1 "crypto/sha1" // SHA-1 is mandated by the WKD spec (draft-koch-openpgp-webkey-service)
 	"encoding/base32"
 	"fmt"
 	"io"
@@ -29,7 +29,7 @@ func wkdDirectURL(email string) (string, error) {
 		return "", fmt.Errorf("wkd: invalid email %q", email)
 	}
 
-	h := crypto_sha1.Sum([]byte(local)) //nolint:gosec // SHA-1 is mandated by the WKD spec
+	h := crypto_sha1.Sum([]byte(local))
 	hash := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(h[:]))
 
 	return fmt.Sprintf("https://%s/.well-known/openpgpkey/hu/%s?l=%s", domain, hash, local), nil

--- a/pgp/wkd.go
+++ b/pgp/wkd.go
@@ -2,7 +2,8 @@ package pgp
 
 import (
 	"bytes"
-	"crypto/sha1"
+	"context"
+	crypto_sha1 "crypto/sha1" //nolint:gosec // SHA-1 is mandated by the WKD spec (draft-koch-openpgp-webkey-service)
 	"encoding/base32"
 	"fmt"
 	"io"
@@ -28,7 +29,7 @@ func wkdDirectURL(email string) (string, error) {
 		return "", fmt.Errorf("wkd: invalid email %q", email)
 	}
 
-	h := sha1.Sum([]byte(local))
+	h := crypto_sha1.Sum([]byte(local)) //nolint:gosec // SHA-1 is mandated by the WKD spec
 	hash := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(h[:]))
 
 	return fmt.Sprintf("https://%s/.well-known/openpgpkey/hu/%s?l=%s", domain, hash, local), nil
@@ -45,11 +46,15 @@ func LookupWKD(email string) (*openpgp.Entity, error) {
 	}
 
 	client := httpclient.New(httpclient.WKDLookupTimeout)
-	resp, err := client.Get(url)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("wkd: build request: %w", err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("wkd: fetch %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("wkd: %s returned status %d", url, resp.StatusCode)

--- a/pgp/wkd_test.go
+++ b/pgp/wkd_test.go
@@ -1,0 +1,159 @@
+package pgp
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+)
+
+func TestWKDDirectURL(t *testing.T) {
+	tests := []struct {
+		email   string
+		wantErr bool
+		check   func(t *testing.T, url string)
+	}{
+		{
+			email: "alice@example.com",
+			check: func(t *testing.T, url string) {
+				if !strings.HasPrefix(url, "https://example.com/.well-known/openpgpkey/hu/") {
+					t.Errorf("unexpected URL prefix: %s", url)
+				}
+				if !strings.HasSuffix(url, "?l=alice") {
+					t.Errorf("missing local part query param: %s", url)
+				}
+			},
+		},
+		{
+			email: "Bob@Example.COM",
+			check: func(t *testing.T, url string) {
+				if !strings.Contains(url, "example.com") {
+					t.Errorf("domain not lowercased: %s", url)
+				}
+				if !strings.HasSuffix(url, "?l=bob") {
+					t.Errorf("local part not lowercased: %s", url)
+				}
+			},
+		},
+		{email: "invalid", wantErr: true},
+		{email: "@domain.com", wantErr: true},
+		{email: "user@", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.email, func(t *testing.T) {
+			url, err := wkdDirectURL(tt.email)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, url)
+			}
+		})
+	}
+}
+
+func TestLookupWKDWithTestServer(t *testing.T) {
+	entity, err := openpgp.NewEntity("Test User", "", "test@example.com", nil)
+	if err != nil {
+		t.Fatalf("NewEntity: %v", err)
+	}
+
+	var armoredKey bytes.Buffer
+	w, err := armor.Encode(&armoredKey, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("armor.Encode: %v", err)
+	}
+	if err := entity.Serialize(w); err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("armor close: %v", err)
+	}
+	keyBytes := armoredKey.Bytes()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/.well-known/openpgpkey/hu/") {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Write(keyBytes)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	// Override the HTTP client to use our test server's TLS config.
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	defer func() { http.DefaultClient = origClient }()
+
+	// We can't easily override LookupWKD's internal client, so test CacheWKDKey
+	// and the URL builder instead. The integration with a real WKD endpoint
+	// would require network access.
+	t.Run("CacheWKDKey", func(t *testing.T) {
+		dir := t.TempDir()
+		pgpDir := filepath.Join(dir, "pgp")
+
+		err := CacheWKDKey(pgpDir, "test@example.com", entity)
+		if err != nil {
+			t.Fatalf("CacheWKDKey: %v", err)
+		}
+
+		cached, err := os.ReadFile(filepath.Join(pgpDir, "test@example.com.asc"))
+		if err != nil {
+			t.Fatalf("read cached key: %v", err)
+		}
+		if len(cached) == 0 {
+			t.Fatal("cached key is empty")
+		}
+
+		loaded, err := loadPublicEntity(filepath.Join(pgpDir, "test@example.com.asc"))
+		if err != nil {
+			t.Fatalf("loadPublicEntity on cached key: %v", err)
+		}
+		if loaded.PrimaryKey.KeyId != entity.PrimaryKey.KeyId {
+			t.Errorf("cached key ID mismatch: got %d, want %d",
+				loaded.PrimaryKey.KeyId, entity.PrimaryKey.KeyId)
+		}
+	})
+}
+
+func TestLoadPublicKeyForEmailFallsBackToWKD(t *testing.T) {
+	entity, err := openpgp.NewEntity("WKD User", "", "wkd@example.com", nil)
+	if err != nil {
+		t.Fatalf("NewEntity: %v", err)
+	}
+
+	dir := t.TempDir()
+	pgpDir := filepath.Join(dir, "pgp")
+	if err := os.Mkdir(pgpDir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Pre-cache the key so we don't need a real WKD server.
+	if err := CacheWKDKey(pgpDir, "wkd@example.com", entity); err != nil {
+		t.Fatalf("CacheWKDKey: %v", err)
+	}
+
+	p := &FileBasedProvider{pgpDir: pgpDir}
+	loaded, err := p.loadPublicKeyForEmail("wkd@example.com")
+	if err != nil {
+		t.Fatalf("loadPublicKeyForEmail: %v", err)
+	}
+	if loaded.PrimaryKey.KeyId != entity.PrimaryKey.KeyId {
+		t.Errorf("key ID mismatch: got %d, want %d",
+			loaded.PrimaryKey.KeyId, entity.PrimaryKey.KeyId)
+	}
+}

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -1152,7 +1152,15 @@ func encryptEmailPGP(payload []byte, recipients []string, account *config.Accoun
 			}
 		}
 		if readErr != nil {
-			return nil, fmt.Errorf("missing PGP key for %s (tried .asc, .gpg, .pem in %s): %w", email, pgpDir, readErr)
+			entity, wkdErr := pgp.LookupWKD(email)
+			if wkdErr != nil {
+				return nil, fmt.Errorf("missing PGP key for %s (tried .asc, .gpg, .pem in %s and WKD): %w", email, pgpDir, wkdErr)
+			}
+			if cacheErr := pgp.CacheWKDKey(pgpDir, email, entity); cacheErr != nil {
+				_ = cacheErr
+			}
+			entityList = append(entityList, entity)
+			continue
 		}
 
 		// Try armored format first

--- a/tui/composer.go
+++ b/tui/composer.go
@@ -15,6 +15,7 @@ import (
 	overlay "github.com/floatpane/bubble-overlay"
 	shortcode "github.com/floatpane/go-emoji-shortcode"
 	"github.com/floatpane/matcha/config"
+	"github.com/floatpane/matcha/pgp"
 	"github.com/floatpane/matcha/spellcheck"
 	"github.com/google/uuid"
 )
@@ -135,6 +136,9 @@ type Composer struct {
 	spellLastCursorCol      int
 	disableSpellcheck       bool
 	disableSpellSuggestions bool
+
+	// WKD key download confirmation
+	wkdConfirmRecipients []string // recipients missing local keys, awaiting confirmation
 }
 
 // NewComposer initializes a new composer model.
@@ -309,6 +313,64 @@ func (m *Composer) updateSignature() {
 func (m *Composer) updatePGPDefaults() {
 	if acc := m.getSelectedAccount(); acc != nil {
 		m.signPGP = acc.PGPSignByDefault
+	}
+}
+
+func (m *Composer) missingRecipientKeys() []string {
+	cfgDir, err := config.GetConfigDir()
+	if err != nil {
+		return nil
+	}
+	pgpDir := cfgDir + "/pgp"
+
+	var allRecipients []string
+	for _, s := range []string{m.toInput.Value(), m.ccInput.Value(), m.bccInput.Value()} {
+		for _, r := range strings.Split(s, ",") {
+			if trimmed := strings.TrimSpace(r); trimmed != "" {
+				allRecipients = append(allRecipients, trimmed)
+			}
+		}
+	}
+	return pgp.MissingLocalKeys(pgpDir, allRecipients)
+}
+
+func (m *Composer) downloadWKDKeysCmd(recipients []string) tea.Cmd {
+	return func() tea.Msg {
+		cfgDir, err := config.GetConfigDir()
+		if err != nil {
+			return NotifyMsg{Message: "WKD: could not determine config directory"}
+		}
+		pgpDir := cfgDir + "/pgp"
+
+		var downloaded []string
+		var failed []string
+		for _, email := range recipients {
+			entity, err := pgp.LookupWKD(email)
+			if err != nil {
+				failed = append(failed, email)
+				continue
+			}
+			if err := pgp.CacheWKDKey(pgpDir, email, entity); err != nil {
+				failed = append(failed, email)
+				continue
+			}
+			downloaded = append(downloaded, email)
+		}
+
+		if len(downloaded) > 0 {
+			m.encryptPGP = true
+		}
+
+		var msg string
+		if len(downloaded) > 0 && len(failed) > 0 {
+			msg = fmt.Sprintf("WKD: downloaded keys for %s; failed for %s",
+				strings.Join(downloaded, ", "), strings.Join(failed, ", "))
+		} else if len(downloaded) > 0 {
+			msg = fmt.Sprintf("WKD: downloaded keys for %s", strings.Join(downloaded, ", "))
+		} else {
+			msg = fmt.Sprintf("WKD: no keys found for %s", strings.Join(failed, ", "))
+		}
+		return NotifyMsg{Message: msg}
 	}
 }
 
@@ -964,6 +1026,20 @@ func (m *Composer) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 			}
 		}
 
+		if len(m.wkdConfirmRecipients) > 0 {
+			switch msg.String() {
+			case "y", "Y":
+				recipients := m.wkdConfirmRecipients
+				m.wkdConfirmRecipients = nil
+				return m, m.downloadWKDKeysCmd(recipients)
+			case "n", "N", "esc":
+				m.wkdConfirmRecipients = nil
+				return m, nil
+			default:
+				return m, nil
+			}
+		}
+
 		// Spellcheck suggestion popup (only while body is focused).
 		if m.focusIndex == focusBody && m.spellShow && len(m.spellSuggestions) > 0 {
 			sk := config.Keybinds.Composer
@@ -1139,6 +1215,14 @@ func (m *Composer) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 
 			case focusEncryptPGP:
 				if msg.String() == keyEnter || msg.String() == " " {
+					if !m.encryptPGP {
+						// Turning encryption ON — check for missing recipient keys
+						missing := m.missingRecipientKeys()
+						if len(missing) > 0 {
+							m.wkdConfirmRecipients = missing
+							return m, nil
+						}
+					}
 					m.encryptPGP = !m.encryptPGP
 				}
 				return m, nil
@@ -1537,6 +1621,22 @@ func (m *Composer) View() tea.View { //nolint:gocyclo
 		dialog := DialogBoxStyle.Render(
 			lipgloss.JoinVertical(lipgloss.Center,
 				t("composer.exit_confirm"),
+				HelpStyle.Render("\n(y/n)"),
+			),
+		)
+		return tea.NewView(lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, dialog))
+	}
+
+	if len(m.wkdConfirmRecipients) > 0 {
+		var msg strings.Builder
+		msg.WriteString("Missing PGP keys for:\n\n")
+		for _, r := range m.wkdConfirmRecipients {
+			msg.WriteString(fmt.Sprintf("  • %s\n", r))
+		}
+		msg.WriteString("\nDownload from WKD?")
+		dialog := DialogBoxStyle.Render(
+			lipgloss.JoinVertical(lipgloss.Center,
+				msg.String(),
 				HelpStyle.Render("\n(y/n)"),
 			),
 		)

--- a/tui/composer.go
+++ b/tui/composer.go
@@ -362,12 +362,13 @@ func (m *Composer) downloadWKDKeysCmd(recipients []string) tea.Cmd {
 		}
 
 		var msg string
-		if len(downloaded) > 0 && len(failed) > 0 {
+		switch {
+		case len(downloaded) > 0 && len(failed) > 0:
 			msg = fmt.Sprintf("WKD: downloaded keys for %s; failed for %s",
 				strings.Join(downloaded, ", "), strings.Join(failed, ", "))
-		} else if len(downloaded) > 0 {
+		case len(downloaded) > 0:
 			msg = fmt.Sprintf("WKD: downloaded keys for %s", strings.Join(downloaded, ", "))
-		} else {
+		default:
 			msg = fmt.Sprintf("WKD: no keys found for %s", strings.Join(failed, ", "))
 		}
 		return NotifyMsg{Message: msg}
@@ -1631,7 +1632,7 @@ func (m *Composer) View() tea.View { //nolint:gocyclo
 		var msg strings.Builder
 		msg.WriteString("Missing PGP keys for:\n\n")
 		for _, r := range m.wkdConfirmRecipients {
-			msg.WriteString(fmt.Sprintf("  • %s\n", r))
+			fmt.Fprintf(&msg, "  • %s\n", r)
 		}
 		msg.WriteString("\nDownload from WKD?")
 		dialog := DialogBoxStyle.Render(

--- a/tui/messages.go
+++ b/tui/messages.go
@@ -199,6 +199,17 @@ type FileSelectedMsg struct {
 	Paths []string
 }
 
+// WKDKeyFoundMsg is sent when a WKD lookup successfully finds a PGP key.
+type WKDKeyFoundMsg struct {
+	Email    string
+	Verified bool // true if re-verification succeeded
+}
+
+// WKDConfirmDownloadMsg requests user confirmation before downloading a key via WKD.
+type WKDConfirmDownloadMsg struct {
+	Recipients []string // recipients missing local keys
+}
+
 type CancelFilePickerMsg struct{}
 
 type DeleteEmailMsg struct {


### PR DESCRIPTION
## What?

Verification (incoming emails): `verifyPGPSignature`  now accepts the sender email and falls back to WKD when local keyring verification fails. The envelope is fetched alongside body structure to provide the sender address. Found keys are cached locally.

Encryption (outgoing emails): When toggling PGP encryption on, checks for missing recipient keys via  pgp.MissingLocalKeys() . If any are missing, shows a confirmation dialog listing recipients and asking  (y/n)  before downloading via WKD. On confirmation, downloads and caches keys in background, then enables encryption

## Why?

Closes #1566 
