### PR TITLE
fix: add cap to image rendering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/yuin/gopher-lua v1.1.2
 	github.com/zalando/go-keyring v0.2.8
 	go.mozilla.org/pkcs7 v0.9.0
-	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
 )
@@ -77,5 +76,6 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.77 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.2
 	github.com/zalando/go-keyring v0.2.8
 	go.mozilla.org/pkcs7 v0.9.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
 )
@@ -76,6 +77,5 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.77 // indirect
 )

--- a/view/html.go
+++ b/view/html.go
@@ -396,12 +396,12 @@ func maxImageCellHeight() int {
 	if !ok || rows < 1 {
 		return defaultRows
 	}
-	max := rows * 8 / 10
-	if max < 1 {
+	limit := rows * 8 / 10
+	if limit < 1 {
 		return 1
 	}
-	if max > defaultRows {
-		return max
+	if limit > defaultRows {
+		return limit
 	}
 	return defaultRows
 }

--- a/view/html.go
+++ b/view/html.go
@@ -18,8 +18,8 @@ import (
 	"github.com/floatpane/matcha/internal/loglevel"
 	"github.com/floatpane/matcha/theme"
 	"github.com/floatpane/termimage"
-	"golang.org/x/sys/unix"
 	lru "github.com/hashicorp/golang-lru/v2"
+	"golang.org/x/sys/unix"
 )
 
 var htmlSanitizer htmlsanitizer.Sanitizer = htmlsanitizer.NewLibSanitizer()

--- a/view/html.go
+++ b/view/html.go
@@ -18,6 +18,7 @@ import (
 	"github.com/floatpane/matcha/internal/loglevel"
 	"github.com/floatpane/matcha/theme"
 	"github.com/floatpane/termimage"
+	"golang.org/x/sys/unix"
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
@@ -363,9 +364,17 @@ const imageRowPlaceholderSuffix = "]]"
 func prerenderImage(payload string) (string, int) {
 	src := "data:image/png;base64," + payload
 	var buf bytes.Buffer
+
+	// Ask termimage to cap the rendered image so it can never exceed the
+	// terminal viewport. This prevents oversized/tall images from covering the
+	// whole screen or overlapping other content on scroll. We always pass a
+	// maximum in cells and let termimage convert to pixels for the active
+	// protocol.
 	_, rows, err := termimage.DisplayWithSize(&buf, src, termimage.Options{
 		Protocol:  termimage.Auto,
 		Sandboxed: true,
+		MaxWidth:  maxImageCellWidth(),
+		MaxHeight: maxImageCellHeight(),
 	})
 	if err != nil {
 		debugImageProtocol("termimage.DisplayWithSize error: %v", err)
@@ -376,6 +385,82 @@ func prerenderImage(payload string) (string, int) {
 	}
 	debugImageProtocol("termimage: prerendered rows=%d bytes=%d", rows, buf.Len())
 	return buf.String(), rows
+}
+
+// maxImageCellHeight returns the maximum number of terminal rows an inline
+// image is allowed to occupy. It is always capped to a fraction of the viewport
+// so images cannot monopolize the screen during scrolling.
+func maxImageCellHeight() int {
+	const defaultRows = 25
+	_, rows, ok := getTerminalSize()
+	if !ok || rows < 1 {
+		return defaultRows
+	}
+	max := rows * 8 / 10
+	if max < 1 {
+		return 1
+	}
+	if max > defaultRows {
+		return max
+	}
+	return defaultRows
+}
+
+// maxImageCellWidth returns the maximum number of terminal columns an inline
+// image is allowed to occupy.
+func maxImageCellWidth() int {
+	const defaultCols = 80
+	cols, _, ok := getTerminalSize()
+	if !ok || cols < 1 {
+		return defaultCols
+	}
+	if cols > 4 {
+		cols -= 4
+	}
+	if cols < 1 {
+		cols = 1
+	}
+	if cols > defaultCols {
+		return cols
+	}
+	return defaultCols
+}
+
+// terminalSize caches the most recent terminal dimensions to avoid repeated
+// syscalls. It is refreshed on demand if the dimensions are unknown.
+var terminalSize struct {
+	cols, rows int
+	ok         bool
+}
+
+// getTerminalSize returns the current terminal size in columns and rows.
+func getTerminalSize() (cols, rows int, ok bool) {
+	if terminalSize.ok {
+		return terminalSize.cols, terminalSize.rows, true
+	}
+	size, ok := terminalSizeFrom(os.Stdin)
+	if !ok {
+		size, ok = terminalSizeFrom(os.Stdout)
+	}
+	if !ok || size.cols < 1 || size.rows < 1 {
+		return 0, 0, false
+	}
+	terminalSize.cols, terminalSize.rows, terminalSize.ok = size.cols, size.rows, true
+	return size.cols, size.rows, true
+}
+
+type termSize struct {
+	cols, rows int
+}
+
+// terminalSizeFrom attempts to read the terminal dimensions using the tty ioctl.
+func terminalSizeFrom(f *os.File) (termSize, bool) {
+	fd := f.Fd()
+	ws, err := unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ)
+	if err != nil || ws.Col == 0 || ws.Row == 0 {
+		return termSize{}, false
+	}
+	return termSize{cols: int(ws.Col), rows: int(ws.Row)}, true
 }
 
 // RenderImageToStdout writes an image directly to stdout at the given screen

--- a/view/html.go
+++ b/view/html.go
@@ -18,8 +18,8 @@ import (
 	"github.com/floatpane/matcha/internal/loglevel"
 	"github.com/floatpane/matcha/theme"
 	"github.com/floatpane/termimage"
-	"golang.org/x/term"
 	lru "github.com/hashicorp/golang-lru/v2"
+	"golang.org/x/term"
 )
 
 var htmlSanitizer htmlsanitizer.Sanitizer = htmlsanitizer.NewLibSanitizer()

--- a/view/html.go
+++ b/view/html.go
@@ -18,8 +18,8 @@ import (
 	"github.com/floatpane/matcha/internal/loglevel"
 	"github.com/floatpane/matcha/theme"
 	"github.com/floatpane/termimage"
+	"golang.org/x/term"
 	lru "github.com/hashicorp/golang-lru/v2"
-	"golang.org/x/sys/unix"
 )
 
 var htmlSanitizer htmlsanitizer.Sanitizer = htmlsanitizer.NewLibSanitizer()
@@ -455,12 +455,11 @@ type termSize struct {
 
 // terminalSizeFrom attempts to read the terminal dimensions using the tty ioctl.
 func terminalSizeFrom(f *os.File) (termSize, bool) {
-	fd := f.Fd()
-	ws, err := unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ)
-	if err != nil || ws.Col == 0 || ws.Row == 0 {
+	cols, rows, err := term.GetSize(int(f.Fd()))
+	if err != nil || cols < 1 || rows < 1 {
 		return termSize{}, false
 	}
-	return termSize{cols: int(ws.Col), rows: int(ws.Row)}, true
+	return termSize{cols: cols, rows: rows}, true
 }
 
 // RenderImageToStdout writes an image directly to stdout at the given screen

--- a/view/html_image_size_test.go
+++ b/view/html_image_size_test.go
@@ -1,0 +1,63 @@
+package view
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMaxImageCellHeight(t *testing.T) {
+	old := terminalSize
+	defer func() { terminalSize = old }()
+
+	terminalSize = struct {
+		cols, rows int
+		ok         bool
+	}{cols: 100, rows: 40, ok: true}
+
+	if got := maxImageCellHeight(); got != 32 {
+		t.Fatalf("expected maxImageCellHeight=32 for 40-row terminal, got %d", got)
+	}
+}
+
+func TestMaxImageCellWidth(t *testing.T) {
+	old := terminalSize
+	defer func() { terminalSize = old }()
+
+	terminalSize = struct {
+		cols, rows int
+		ok         bool
+	}{cols: 100, rows: 40, ok: true}
+
+	if got := maxImageCellWidth(); got != 96 {
+		t.Fatalf("expected maxImageCellWidth=96 for 100-col terminal, got %d", got)
+	}
+}
+
+func TestMaxImageCellDefaultsWhenNoTerminal(t *testing.T) {
+	old := terminalSize
+	defer func() { terminalSize = old }()
+
+	terminalSize = struct {
+		cols, rows int
+		ok         bool
+	}{}
+
+	if got := maxImageCellHeight(); got != 25 {
+		t.Fatalf("expected default height 25, got %d", got)
+	}
+	if got := maxImageCellWidth(); got != 80 {
+		t.Fatalf("expected default width 80, got %d", got)
+	}
+}
+
+func TestTerminalSizeFrom(t *testing.T) {
+	// The current process stdin/stdout may or may not be a terminal. We just
+	// verify the helper doesn't panic and returns sensible values when given a
+	// valid file.
+	ts, ok := terminalSizeFrom(os.Stdout)
+	if ok {
+		if ts.cols < 1 || ts.rows < 1 {
+			t.Fatalf("unexpected terminal size: %+v", ts)
+		}
+	}
+}

--- a/view/html_image_size_test.go
+++ b/view/html_image_size_test.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"os"
+	"runtime"
 	"testing"
 )
 
@@ -51,6 +52,9 @@ func TestMaxImageCellDefaultsWhenNoTerminal(t *testing.T) {
 }
 
 func TestTerminalSizeFrom(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TIOCGWINSZ is unavailable on Windows")
+	}
 	// The current process stdin/stdout may or may not be a terminal. We just
 	// verify the helper doesn't panic and returns sensible values when given a
 	// valid file.


### PR DESCRIPTION
## What?

Adds a cap to image rendering, so that the images dont break the whole TUI

## Why?

Previously, big images would make the whole screen black, when scrolled.
