### PR TITLE
feat: install themes via CLI

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -13,7 +13,12 @@ import (
 	"github.com/floatpane/matcha/plugins"
 )
 
-const rawThemeBaseURL = "https://raw.githubusercontent.com/floatpane/matcha-themes/master/themes/"
+const (
+	rawThemeBaseURL = "https://raw.githubusercontent.com/floatpane/matcha-themes/master/themes/"
+
+	installKindPlugin = "plugin"
+	installKindTheme  = "theme"
+)
 
 // RunInstall handles `matcha install [plugin|theme] <name_or_url_or_file>`.
 func RunInstall(args []string) error {
@@ -24,9 +29,9 @@ func RunInstall(args []string) error {
 	kind, source := detectKind(args)
 
 	switch kind {
-	case "theme":
+	case installKindTheme:
 		return installTheme(source)
-	case "plugin":
+	case installKindPlugin:
 		return installPlugin(source)
 	default:
 		return fmt.Errorf("unknown install kind: %s", kind)
@@ -38,10 +43,10 @@ func RunInstall(args []string) error {
 func detectKind(args []string) (string, string) {
 	if len(args) >= 2 {
 		switch args[0] {
-		case "plugin":
-			return "plugin", args[1]
-		case "theme":
-			return "theme", args[1]
+		case installKindPlugin:
+			return installKindPlugin, args[1]
+		case installKindTheme:
+			return installKindTheme, args[1]
 		}
 	}
 
@@ -50,9 +55,9 @@ func detectKind(args []string) (string, string) {
 	// Explicit URLs or local files are downloaded as-is; infer from extension.
 	if isURL(source) || isFilePath(source) {
 		if strings.HasSuffix(source, ".json") {
-			return "theme", source
+			return installKindTheme, source
 		}
-		return "plugin", source
+		return installKindPlugin, source
 	}
 
 	// Ambiguous bare name: check for collisions between plugin/theme names.
@@ -60,17 +65,17 @@ func detectKind(args []string) (string, string) {
 	isThemeName := isKnownThemeName(source)
 
 	if isPluginName && !isThemeName {
-		return "plugin", source
+		return installKindPlugin, source
 	}
 	if isThemeName && !isPluginName {
-		return "theme", source
+		return installKindTheme, source
 	}
 	if isPluginName && isThemeName {
 		return "", source
 	}
 
 	// Unknown name: assume plugin to preserve existing behavior.
-	return "plugin", source
+	return installKindPlugin, source
 }
 
 func isURL(s string) bool {
@@ -96,7 +101,7 @@ func isKnownPluginName(name string) bool {
 
 func isKnownThemeName(name string) bool {
 	client := httpclient.New(httpclient.RegistryFetchTimeout)
-	resp, err := client.Get(fmt.Sprintf("https://api.github.com/repos/floatpane/matcha-themes/contents/themes?ref=master")) //nolint:noctx
+	resp, err := client.Get("https://api.github.com/repos/floatpane/matcha-themes/contents/themes?ref=master") //nolint:noctx
 	if err != nil {
 		return false
 	}
@@ -137,7 +142,7 @@ func installPlugin(source string) error {
 	}
 
 	dest := filepath.Join(dir, filename)
-	if err := os.WriteFile(dest, data, 0o644); err != nil { //nolint:gosec
+	if err := os.WriteFile(dest, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write plugin: %w", err)
 	}
 
@@ -198,7 +203,7 @@ func installTheme(source string) error {
 	}
 
 	dest := filepath.Join(dir, filename)
-	if err := os.WriteFile(dest, data, 0o644); err != nil { //nolint:gosec
+	if err := os.WriteFile(dest, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write theme: %w", err)
 	}
 

--- a/cli/install.go
+++ b/cli/install.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,65 +10,296 @@ import (
 	"strings"
 
 	"github.com/floatpane/matcha/internal/httpclient"
+	"github.com/floatpane/matcha/plugins"
 )
 
-// RunInstall handles `matcha install <url_or_file>`.
+const rawThemeBaseURL = "https://raw.githubusercontent.com/floatpane/matcha-themes/master/themes/"
+
+// RunInstall handles `matcha install [plugin|theme] <name_or_url_or_file>`.
 func RunInstall(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: matcha install <url_or_file>")
+		return fmt.Errorf("usage: matcha install [plugin|theme] <name_or_url_or_file>")
+	}
+
+	kind, source := detectKind(args)
+
+	switch kind {
+	case "theme":
+		return installTheme(source)
+	case "plugin":
+		return installPlugin(source)
+	default:
+		return fmt.Errorf("unknown install kind: %s", kind)
+	}
+}
+
+// detectKind resolves the install kind and source from the command arguments.
+// It returns ("plugin"|"theme", source).
+func detectKind(args []string) (string, string) {
+	if len(args) >= 2 {
+		switch args[0] {
+		case "plugin":
+			return "plugin", args[1]
+		case "theme":
+			return "theme", args[1]
+		}
 	}
 
 	source := args[0]
-	var data []byte
-	var filename string
 
-	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
-		// Download from URL
-		client := httpclient.New(httpclient.InstallTimeout)
-		resp, err := client.Get(source) //nolint:noctx
-		if err != nil {
-			return fmt.Errorf("failed to download: %w", err)
+	// Explicit URLs or local files are downloaded as-is; infer from extension.
+	if isURL(source) || isFilePath(source) {
+		if strings.HasSuffix(source, ".json") {
+			return "theme", source
 		}
-		defer resp.Body.Close() //nolint:errcheck
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("download returned status %d", resp.StatusCode)
-		}
-
-		data, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read response: %w", err)
-		}
-
-		// Extract filename from URL path
-		parts := strings.Split(strings.TrimRight(source, "/"), "/")
-		filename = parts[len(parts)-1]
-	} else {
-		// Read from local file
-		var err error
-		data, err = os.ReadFile(source)
-		if err != nil {
-			return fmt.Errorf("failed to read file: %w", err)
-		}
-		filename = filepath.Base(source)
+		return "plugin", source
 	}
 
-	if !strings.HasSuffix(filename, ".lua") {
-		return fmt.Errorf("plugin file must have a .lua extension")
+	// Ambiguous bare name: check for collisions between plugin/theme names.
+	isPluginName := isKnownPluginName(source)
+	isThemeName := isKnownThemeName(source)
+
+	if isPluginName && !isThemeName {
+		return "plugin", source
+	}
+	if isThemeName && !isPluginName {
+		return "theme", source
+	}
+	if isPluginName && isThemeName {
+		return "", source
 	}
 
-	pluginsDir, err := pluginsDir()
+	// Unknown name: assume plugin to preserve existing behavior.
+	return "plugin", source
+}
+
+func isURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+func isFilePath(s string) bool {
+	return strings.Contains(s, string(filepath.Separator)) || strings.HasPrefix(s, ".") || filepath.IsAbs(s)
+}
+
+func isKnownPluginName(name string) bool {
+	entries, err := plugins.FetchRegistry()
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if strings.EqualFold(e.Name, name) || strings.EqualFold(strings.TrimSuffix(e.File, ".lua"), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func isKnownThemeName(name string) bool {
+	client := httpclient.New(httpclient.RegistryFetchTimeout)
+	resp, err := client.Get(fmt.Sprintf("https://api.github.com/repos/floatpane/matcha-themes/contents/themes?ref=master")) //nolint:noctx
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	var items []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return false
+	}
+
+	for _, item := range items {
+		if strings.EqualFold(strings.TrimSuffix(item.Name, ".json"), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func installPlugin(source string) error {
+	data, filename, err := resolvePluginSource(source)
 	if err != nil {
 		return err
 	}
 
-	dest := filepath.Join(pluginsDir, filename)
-	if err := os.WriteFile(dest, data, 0o644); err != nil {
+	if !strings.HasSuffix(filename, ".lua") {
+		filename += ".lua"
+	}
+
+	dir, err := pluginsDir()
+	if err != nil {
+		return err
+	}
+
+	dest := filepath.Join(dir, filename)
+	if err := os.WriteFile(dest, data, 0o644); err != nil { //nolint:gosec
 		return fmt.Errorf("failed to write plugin: %w", err)
 	}
 
-	fmt.Printf("Installed %s to %s\n", filename, dest)
+	fmt.Printf("Installed plugin %s to %s\n", filename, dest)
 	return nil
+}
+
+func resolvePluginSource(source string) ([]byte, string, error) {
+	if isURL(source) {
+		data, err := download(source)
+		if err != nil {
+			return nil, "", err
+		}
+		parts := strings.Split(strings.TrimRight(source, "/"), "/")
+		return data, parts[len(parts)-1], nil
+	}
+
+	// Bare name from registry.
+	entries, err := plugins.FetchRegistry()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to fetch plugin registry: %w", err)
+	}
+	for _, e := range entries {
+		if strings.EqualFold(e.Name, source) || strings.EqualFold(strings.TrimSuffix(e.File, ".lua"), source) {
+			data, err := plugins.FetchPlugin(e)
+			if err != nil {
+				return nil, "", err
+			}
+			return data, e.File, nil
+		}
+	}
+
+	// Local file fallback.
+	data, err := os.ReadFile(source)
+	if err != nil {
+		return nil, "", fmt.Errorf("plugin not found: %s", source)
+	}
+	return data, filepath.Base(source), nil
+}
+
+func installTheme(source string) error {
+	data, filename, err := resolveThemeSource(source)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasSuffix(filename, ".json") {
+		filename += ".json"
+	}
+
+	if err := validateThemeJSON(data); err != nil {
+		return err
+	}
+
+	dir, err := themesDir()
+	if err != nil {
+		return err
+	}
+
+	dest := filepath.Join(dir, filename)
+	if err := os.WriteFile(dest, data, 0o644); err != nil { //nolint:gosec
+		return fmt.Errorf("failed to write theme: %w", err)
+	}
+
+	fmt.Printf("Installed theme %s to %s\n", filename, dest)
+	return nil
+}
+
+func resolveThemeSource(source string) ([]byte, string, error) {
+	if isURL(source) {
+		data, err := download(source)
+		if err != nil {
+			return nil, "", err
+		}
+		parts := strings.Split(strings.TrimRight(source, "/"), "/")
+		return data, parts[len(parts)-1], nil
+	}
+
+	// GitHub repo shorthand: owner/repo:path/to/file.json
+	if repoRef, path, ok := splitRepoRef(source); ok {
+		url := fmt.Sprintf("https://raw.githubusercontent.com/%s/master/%s", repoRef, path)
+		data, err := download(url)
+		if err != nil {
+			return nil, "", err
+		}
+		return data, filepath.Base(path), nil
+	}
+
+	// Bare name from official matcha-themes registry.
+	filename := source
+	if !strings.HasSuffix(filename, ".json") {
+		filename += ".json"
+	}
+	data, err := download(rawThemeBaseURL + filename)
+	if err != nil {
+		return nil, "", fmt.Errorf("theme not found: %s", source)
+	}
+	return data, filename, nil
+}
+
+// splitRepoRef parses "owner/repo:path/to/file" into (owner/repo, path, true).
+func splitRepoRef(s string) (string, string, bool) {
+	if strings.Count(s, "/") < 1 || strings.Count(s, ":") != 1 {
+		return "", "", false
+	}
+	colon := strings.Index(s, ":")
+	if colon <= 0 {
+		return "", "", false
+	}
+	repoRef := s[:colon]
+	path := s[colon+1:]
+	if strings.Count(repoRef, "/") != 1 || repoRef[0] == '/' || repoRef[len(repoRef)-1] == '/' {
+		return "", "", false
+	}
+	if path == "" {
+		return "", "", false
+	}
+	return repoRef, path, true
+}
+
+func validateThemeJSON(data []byte) error {
+	var theme struct {
+		Name       string `json:"name"`
+		Accent     string `json:"accent"`
+		AccentDark string `json:"accent_dark"`
+		AccentText string `json:"accent_text"`
+		Secondary  string `json:"secondary"`
+		SubtleText string `json:"subtle_text"`
+		MutedText  string `json:"muted_text"`
+		DimText    string `json:"dim_text"`
+		Danger     string `json:"danger"`
+		Warning    string `json:"warning"`
+		Tip        string `json:"tip"`
+		Link       string `json:"link"`
+		Directory  string `json:"directory"`
+		Contrast   string `json:"contrast"`
+	}
+	if err := json.Unmarshal(data, &theme); err != nil {
+		return fmt.Errorf("theme file is not valid JSON: %w", err)
+	}
+	if theme.Name == "" {
+		return fmt.Errorf("theme is missing required field: name")
+	}
+	if theme.Accent == "" || theme.AccentDark == "" || theme.Contrast == "" {
+		return fmt.Errorf("theme is missing required color fields")
+	}
+	return nil
+}
+
+func download(url string) ([]byte, error) {
+	client := httpclient.New(httpclient.InstallTimeout)
+	resp, err := client.Get(url) //nolint:noctx
+	if err != nil {
+		return nil, fmt.Errorf("failed to download: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
 }
 
 func pluginsDir() (string, error) {
@@ -78,6 +310,18 @@ func pluginsDir() (string, error) {
 	dir := filepath.Join(home, ".config", "matcha", "plugins")
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return "", fmt.Errorf("cannot create plugins directory: %w", err)
+	}
+	return dir, nil
+}
+
+func themesDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot find home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".config", "matcha", "themes")
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return "", fmt.Errorf("cannot create themes directory: %w", err)
 	}
 	return dir, nil
 }


### PR DESCRIPTION
## What?

Adds theme installation to `matcha install` CLI command to support the new matcha-themes store of themes.

## Why?

Previously, you had to download the themes on your computer and move them to the themes folder manually.
