### PR TITLE
chore: removes onboarding from gif demo

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -42,8 +42,10 @@ jobs:
                 "password": "dummy-password",
                 "service_provider": "custom",
                 "fetch_email": "matcha@floatpane.com"
-              }
-            ]
+              },
+              "has_seen_setup_guide": true
+            }
+          ]
           }
           EOF
       - name: Build Matcha


### PR DESCRIPTION
## What?

Adds `has_seen_setup_guide` parameter to the config file of demo GIF workflow.

## Why?

Currently generated GIF contains the set up guide, and it is unnecessary in the demo.


