### PR TITLE
fix: adds retries to fetch

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -60,6 +60,8 @@ type logEntryMsg struct {
 
 type clearErrorNotifMsg struct{}
 
+const maxBodyFetchRetries = 3
+
 // Model is the main Bubble Tea application model that orchestrates the TUI.
 type Model struct {
 	current       tea.Model
@@ -96,6 +98,10 @@ type Model struct {
 
 	errorNotification overlay.Notification
 	showErrorNotif    bool
+
+	// Track body fetch retries to prevent infinite loops
+	pendingBodyFetchUID   uint32
+	pendingBodyFetchCount int
 }
 
 // NewModel creates the initial TUI model.
@@ -1233,14 +1239,40 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 		return m, fetchcmd.FetchPreviewBodyCmd(m.config, msg.UID, msg.AccountID, folderName)
 
 	case tui.PreviewBodyFetchedMsg:
-		if msg.Err == nil && m.folderInbox != nil {
-			m.cacheEmailBody(m.folderName(), msg.UID, msg.AccountID, msg.Body, msg.BodyMIMEType, msg.Attachments)
+		if msg.Err != nil {
+			log.Printf("preview body fetch error for UID %d: %v", msg.UID, msg.Err)
+			m.pendingBodyFetchUID = 0
+			m.pendingBodyFetchCount = 0
+			return m, m.showErrorCmd(msg.Err.Error())
 		}
-		if m.folderInbox != nil {
-			m.current, cmd = m.current.Update(msg)
-			return m, cmd
+		if m.folderInbox == nil {
+			m.pendingBodyFetchUID = 0
+			m.pendingBodyFetchCount = 0
+			return m, nil
 		}
-		return m, nil
+		// If body is empty or whitespace-only, retry the fetch (up to max retries)
+		if strings.TrimSpace(msg.Body) == "" {
+			if m.pendingBodyFetchUID == msg.UID && m.pendingBodyFetchCount >= maxBodyFetchRetries {
+				log.Printf("preview body still empty after %d retries for UID %d, showing error", maxBodyFetchRetries, msg.UID)
+				m.pendingBodyFetchUID = 0
+				m.pendingBodyFetchCount = 0
+				return m, m.showErrorCmd("Email body could not be loaded after multiple attempts")
+			}
+			m.pendingBodyFetchUID = msg.UID
+			m.pendingBodyFetchCount++
+			log.Printf("preview body empty for UID %d, retrying fetch (%d/%d)", msg.UID, m.pendingBodyFetchCount, maxBodyFetchRetries)
+			return m, tea.Batch(
+				m.current.Init(),
+				fetchcmd.FetchPreviewBodyCmd(m.config, msg.UID, msg.AccountID, m.folderName()),
+			)
+		}
+		// Reset retry counter on successful fetch
+		m.pendingBodyFetchUID = 0
+		m.pendingBodyFetchCount = 0
+		// Cache the valid body
+		m.cacheEmailBody(m.folderName(), msg.UID, msg.AccountID, msg.Body, msg.BodyMIMEType, msg.Attachments)
+		m.current, cmd = m.current.Update(msg)
+		return m, cmd
 
 	case tui.EmailMovedMsg:
 		if msg.Err != nil {
@@ -1656,11 +1688,35 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 	case tui.EmailBodyFetchedMsg:
 		if msg.Err != nil {
 			log.Printf("could not fetch email body: %v", msg.Err)
+			m.pendingBodyFetchUID = 0
+			m.pendingBodyFetchCount = 0
 			if m.folderInbox != nil {
 				m.current = m.folderInbox
 			}
 			return m, m.showErrorCmd(msg.Err.Error())
 		}
+		// If body is empty or whitespace-only, retry the fetch instead of showing incomplete content
+		if strings.TrimSpace(msg.Body) == "" {
+			if m.pendingBodyFetchUID == msg.UID && m.pendingBodyFetchCount >= maxBodyFetchRetries {
+				log.Printf("email body still empty after %d retries for UID %d, showing error", maxBodyFetchRetries, msg.UID)
+				m.pendingBodyFetchUID = 0
+				m.pendingBodyFetchCount = 0
+				if m.folderInbox != nil {
+					m.current = m.folderInbox
+				}
+				return m, m.showErrorCmd("Email body could not be loaded after multiple attempts")
+			}
+			m.pendingBodyFetchUID = msg.UID
+			m.pendingBodyFetchCount++
+			log.Printf("email body empty for UID %d, retrying fetch (%d/%d)", msg.UID, m.pendingBodyFetchCount, maxBodyFetchRetries)
+			m.current = tui.NewStatus("Fetching email content...")
+			return m, tea.Batch(
+				append(m.pluginFlagCmds(), m.current.Init(), fetchcmd.FetchFolderEmailBodyCmd(m.config, msg.UID, msg.AccountID, m.folderName(), msg.Mailbox), m.pluginNotifyCmd())...,
+			)
+		}
+		// Reset retry counter on successful fetch
+		m.pendingBodyFetchUID = 0
+		m.pendingBodyFetchCount = 0
 		m.store.UpdateEmailBodyByUID(msg.UID, msg.AccountID, msg.Body, msg.BodyMIMEType, msg.Attachments)
 		folderForCache := m.folderName()
 		m.cacheEmailBody(folderForCache, msg.UID, msg.AccountID, msg.Body, msg.BodyMIMEType, msg.Attachments)

--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -641,3 +641,40 @@ func TestLRU_ConcurrentReadWrite(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestEmailBody_EmptyBodyNotCached(t *testing.T) {
+	setup(t)
+
+	// Empty body should not be cached
+	emptyBody := CachedEmailBody{UID: 1, AccountID: "account", Body: ""}
+	threshold := 100 * 1024 * 1024
+
+	if err := SaveEmailBody("INBOX", emptyBody, threshold); err != nil {
+		t.Fatalf("SaveEmailBody: %v", err)
+	}
+
+	// Should not find the empty body in cache
+	if got := GetCachedEmailBody("INBOX", 1, "account", threshold); got != nil {
+		t.Error("Empty body should not be cached")
+	}
+
+	// Whitespace-only body should also not be cached
+	whitespaceBody := CachedEmailBody{UID: 2, AccountID: "account", Body: "   \n\t  "}
+	if err := SaveEmailBody("INBOX", whitespaceBody, threshold); err != nil {
+		t.Fatalf("SaveEmailBody: %v", err)
+	}
+
+	if got := GetCachedEmailBody("INBOX", 2, "account", threshold); got != nil {
+		t.Error("Whitespace-only body should not be cached")
+	}
+
+	// Non-empty body should still be cached
+	validBody := CachedEmailBody{UID: 3, AccountID: "account", Body: "Hello World"}
+	if err := SaveEmailBody("INBOX", validBody, threshold); err != nil {
+		t.Fatalf("SaveEmailBody: %v", err)
+	}
+
+	if got := GetCachedEmailBody("INBOX", 3, "account", threshold); got == nil {
+		t.Error("Valid non-empty body should be cached")
+	}
+}

--- a/config/lru.go
+++ b/config/lru.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -252,6 +253,13 @@ func (lru *LRU) Put(folder string, uid uint32, accountID string, body *CachedEma
 	defer lru.mu.Unlock()
 
 	key := lru.makeKey(folder, uid, accountID)
+
+	// Don't cache empty bodies to prevent storing incomplete fetches
+	if strings.TrimSpace(body.Body) == "" {
+		lru.removeKey(key)
+		_ = removeBodyFromDisk(folder, uid, accountID)
+		return
+	}
 
 	if body.SizeBytes > lru.threshold {
 		lru.removeKey(key)


### PR DESCRIPTION
## What?

Adds 

1. Validation of emails before caching. If matcha receives an empty body, it will not be cached.
2. Adds a re-fetch method to matcha, when the user receives an empty email.

## Why?

When there is a network issue, or a problem with the server and the client receives and empty email, it displays and stores it in cache, making it impossible to read this email without deleting the folder cache.
