### PR TITLE
feat: more HTML tags

### DIFF
--- a/clib/htmlconv.c
+++ b/clib/htmlconv.c
@@ -83,6 +83,7 @@ static HTMLElement* result_add(HTMLConvertResult* r) {
     }
     HTMLElement* e = &r->elements[r->count++];
     e->type = HELEM_TEXT;
+    e->style = 0;
     e->text = NULL;
     e->attr1 = NULL;
     e->attr2 = NULL;
@@ -90,10 +91,11 @@ static HTMLElement* result_add(HTMLConvertResult* r) {
 }
 
 // Flush accumulated text buffer as a TEXT element.
-static void flush_text(HTMLConvertResult* r, Buffer* buf) {
+static void flush_text(HTMLConvertResult* r, Buffer* buf, int style) {
     if (buf->len == 0) return;
     HTMLElement* e = result_add(r);
     e->type = HELEM_TEXT;
+    e->style = style;
     e->text = buf_finish(buf);
     buf_init(buf);
 }
@@ -319,6 +321,7 @@ static void extract_language(const char* klass, char* out, size_t out_size) {
 
 // Tag stack for nesting tracking.
 #define MAX_STACK 128
+#define MAX_LIST_DEPTH 16
 
 typedef struct {
     int in_style;      // Inside <style>
@@ -332,6 +335,7 @@ typedef struct {
     Buffer a_text;     // Current link text accumulator
     int in_h1;
     int in_h2;
+    int h_level;       // Active heading level (0 = none, 1-6)
     Buffer h_text;     // Current header text accumulator
     int bq_depth;      // Blockquote nesting depth
     Buffer bq_text;    // Current blockquote text accumulator
@@ -349,6 +353,17 @@ typedef struct {
     int header_rows;    // Number of header rows (rows inside <thead>)
     Buffer cell_text;   // Current cell text accumulator
     Buffer table_data;  // Accumulated table data (cells tab-separated, rows newline-separated)
+    // List state
+    int list_depth;                       // Current nesting depth (0 = not in a list)
+    int list_ordered[MAX_LIST_DEPTH];     // 1 if <ol>, 0 if <ul>, at each depth
+    int list_index[MAX_LIST_DEPTH];       // 1-based item index per depth
+    int in_li;                            // Currently inside a <li>
+    Buffer li_buf;                        // Current list item text accumulator
+    int pending_space;                    // Keep next leading space after a span flush
+    // Inline text style stack (bitmask of HTML_STYLE_*)
+    int style_stack[MAX_STACK];
+    int style_depth;
+    int cur_style;                        // Current combined style mask
 } ParseState;
 
 HTMLConvertResult html_to_elements(const char* html, size_t len) {
@@ -370,6 +385,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
     buf_init(&state.cell_text);
     buf_init(&state.table_data);
     buf_init(&state.pre_buf);
+    buf_init(&state.li_buf);
 
     Buffer text_buf;
     buf_init(&text_buf);
@@ -379,6 +395,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
 
     while (p < end) {
         if (*p == '<') {
+            state.pending_space = 0;
             // Check for comment
             if (p + 3 < end && p[1] == '!' && p[2] == '-' && p[3] == '-') {
                 const char* ce = strstr(p + 4, "-->");
@@ -425,10 +442,12 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
                     buf_append_char(&state.cell_text, ' ');
                 } else if (state.in_a) {
                     buf_append_char(&state.a_text, '\n');
-                } else if (state.in_h1 || state.in_h2) {
+                } else if (state.h_level > 0) {
                     buf_append_char(&state.h_text, ' ');
                 } else if (state.bq_depth > 0) {
                     buf_append_char(&state.bq_text, '\n');
+                } else if (state.in_li) {
+                    buf_append_char(&state.li_buf, '\n');
                 } else {
                     buf_append_char(&text_buf, '\n');
                 }
@@ -440,7 +459,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
             if (tag_eq(tag.name, tag.name_len, "pre")) {
                 if (!tag.is_closing) {
                     if (state.pre_depth == 0) {
-                        flush_text(&result, &text_buf);
+                        flush_text(&result, &text_buf, state.cur_style);
                         buf_free(&state.pre_buf);
                         buf_init(&state.pre_buf);
                         state.pre_lang[0] = '\0';
@@ -454,7 +473,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
                     state.pre_depth--;
                     if (state.pre_depth == 0) {
                         state.in_pre = 0;
-                        flush_text(&result, &text_buf);
+                        flush_text(&result, &text_buf, state.cur_style);
                         HTMLElement* e = result_add(&result);
                         e->type = HELEM_CODE;
                         e->text = buf_finish(&state.pre_buf);
@@ -483,43 +502,34 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
                 continue;
             }
 
-            // <h1>
-            if (tag_eq(tag.name, tag.name_len, "h1")) {
-                if (tag.is_closing && state.in_h1) {
-                    state.in_h1 = 0;
-                    flush_text(&result, &text_buf);
+            // <h1> - <h6>
+            if (tag.name_len == 2 && (tag.name[0] == 'h' || tag.name[0] == 'H') &&
+                tag.name[1] >= '1' && tag.name[1] <= '6') {
+                int level = tag.name[1] - '0';
+                if (tag.is_closing && state.h_level == level) {
+                    state.h_level = 0;
+                    if (level == 1) state.in_h1 = 0;
+                    if (level == 2) state.in_h2 = 0;
+                    flush_text(&result, &text_buf, state.cur_style);
                     HTMLElement* e = result_add(&result);
-                    e->type = HELEM_H1;
-                    e->text = buf_finish(&state.h_text);
-                    buf_init(&state.h_text);
-                    // Add block spacing
-                    HTMLElement* sp = result_add(&result);
-                    sp->type = HELEM_TEXT;
-                    sp->text = strdup("\n\n");
-                } else if (!tag.is_closing) {
-                    flush_text(&result, &text_buf);
-                    state.in_h1 = 1;
-                    buf_init(&state.h_text);
-                }
-                p = after;
-                continue;
-            }
-
-            // <h2>
-            if (tag_eq(tag.name, tag.name_len, "h2")) {
-                if (tag.is_closing && state.in_h2) {
-                    state.in_h2 = 0;
-                    flush_text(&result, &text_buf);
-                    HTMLElement* e = result_add(&result);
-                    e->type = HELEM_H2;
+                    switch (level) {
+                        case 1: e->type = HELEM_H1; break;
+                        case 2: e->type = HELEM_H2; break;
+                        case 3: e->type = HELEM_H3; break;
+                        case 4: e->type = HELEM_H4; break;
+                        case 5: e->type = HELEM_H5; break;
+                        case 6: e->type = HELEM_H6; break;
+                    }
                     e->text = buf_finish(&state.h_text);
                     buf_init(&state.h_text);
                     HTMLElement* sp = result_add(&result);
                     sp->type = HELEM_TEXT;
                     sp->text = strdup("\n\n");
                 } else if (!tag.is_closing) {
-                    flush_text(&result, &text_buf);
-                    state.in_h2 = 1;
+                    flush_text(&result, &text_buf, state.cur_style);
+                    state.h_level = level;
+                    if (level == 1) state.in_h1 = 1;
+                    if (level == 2) state.in_h2 = 1;
                     buf_init(&state.h_text);
                 }
                 p = after;
@@ -530,14 +540,19 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
             if (tag_eq(tag.name, tag.name_len, "a")) {
                 if (tag.is_closing && state.in_a) {
                     state.in_a = 0;
-                    // If inside blockquote, emit link text inline
+                    // If inside blockquote or list item, emit link text inline
                     if (state.bq_depth > 0) {
                         if (state.a_text.len > 0) {
                             buf_append(&state.bq_text, state.a_text.data, state.a_text.len);
                         }
                         buf_free(&state.a_text);
+                    } else if (state.in_li) {
+                        if (state.a_text.len > 0) {
+                            buf_append(&state.li_buf, state.a_text.data, state.a_text.len);
+                        }
+                        buf_free(&state.a_text);
                     } else {
-                        flush_text(&result, &text_buf);
+                        flush_text(&result, &text_buf, state.cur_style);
                         HTMLElement* e = result_add(&result);
                         e->type = HELEM_LINK;
                         e->text = buf_finish(&state.a_text);
@@ -545,7 +560,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
                         buf_init(&state.a_text);
                     }
                 } else if (!tag.is_closing && tag.href[0]) {
-                    if (state.bq_depth == 0) flush_text(&result, &text_buf);
+                    if (state.bq_depth == 0 && !state.in_li) flush_text(&result, &text_buf, state.cur_style);
                     state.in_a = 1;
                     strncpy(state.a_href, tag.href, sizeof(state.a_href) - 1);
                     state.a_href[sizeof(state.a_href) - 1] = '\0';
@@ -558,7 +573,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
             // <img>
             if (tag_eq(tag.name, tag.name_len, "img")) {
                 if (tag.src[0]) {
-                    flush_text(&result, &text_buf);
+                    flush_text(&result, &text_buf, state.cur_style);
                     HTMLElement* e = result_add(&result);
                     e->type = HELEM_IMAGE;
                     e->attr1 = strdup(tag.src);
@@ -573,7 +588,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
                 if (tag.is_closing && state.bq_depth > 0) {
                     state.bq_depth--;
                     if (state.bq_depth == 0) {
-                        flush_text(&result, &text_buf);
+                        flush_text(&result, &text_buf, state.cur_style);
                         HTMLElement* e = result_add(&result);
                         e->type = HELEM_BLOCKQUOTE;
                         e->text = buf_finish(&state.bq_text);
@@ -603,7 +618,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
                                 buf_append(&state.bq_prev, text_buf.data + line_start, line_len);
                             }
                         }
-                        flush_text(&result, &text_buf);
+                        flush_text(&result, &text_buf, state.cur_style);
                         buf_init(&state.bq_text);
                     }
                     if (tag.cite[0]) {
@@ -623,7 +638,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
                     if (state.table_depth == state.capture_depth) {
                         // Closing the data table we're capturing
                         if (state.table_data.len > 0) {
-                            flush_text(&result, &text_buf);
+                            flush_text(&result, &text_buf, state.cur_style);
                             HTMLElement* e = result_add(&result);
                             e->type = HELEM_TABLE;
                             e->text = buf_finish(&state.table_data);
@@ -739,15 +754,149 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
                 continue;
             }
 
+            // <hr> — emit a horizontal rule element
+            if (tag_eq(tag.name, tag.name_len, "hr")) {
+                flush_text(&result, &text_buf, state.cur_style);
+                HTMLElement* e = result_add(&result);
+                e->type = HELEM_HR;
+                e->text = strdup("");
+                HTMLElement* sp = result_add(&result);
+                sp->type = HELEM_TEXT;
+                sp->text = strdup("\n\n");
+                p = after;
+                continue;
+            }
+
+            // <ul>, <ol>
+            if (tag_eq(tag.name, tag.name_len, "ul") ||
+                tag_eq(tag.name, tag.name_len, "ol")) {
+                if (!tag.is_closing) {
+                    if (state.in_li && state.li_buf.len > 0) {
+                        flush_text(&result, &text_buf, state.cur_style);
+                        HTMLElement* e = result_add(&result);
+                        e->type = HELEM_LIST_ITEM;
+                        e->text = buf_finish(&state.li_buf);
+                        buf_init(&state.li_buf);
+                        char depth_buf[16];
+                        int outer_depth = state.list_depth - 1;
+                        if (outer_depth < 0) outer_depth = 0;
+                        snprintf(depth_buf, sizeof(depth_buf), "%d", outer_depth);
+                        e->attr1 = strdup(depth_buf);
+                        if (state.list_depth > 0 &&
+                            state.list_ordered[state.list_depth - 1]) {
+                            char idx_buf[16];
+                            snprintf(idx_buf, sizeof(idx_buf), "%d",
+                                     state.list_index[state.list_depth - 1]);
+                            e->attr2 = strdup(idx_buf);
+                            state.list_index[state.list_depth - 1]++;
+                        }
+                    }
+                    if (state.list_depth < MAX_LIST_DEPTH) {
+                        state.list_depth++;
+                        state.list_ordered[state.list_depth - 1] =
+                            tag_eq(tag.name, tag.name_len, "ol") ? 1 : 0;
+                        state.list_index[state.list_depth - 1] = 1;
+                    }
+                    if (state.bq_depth == 0 && !state.in_li) flush_text(&result, &text_buf, state.cur_style);
+                } else if (state.list_depth > 0) {
+                    state.list_depth--;
+                    if (state.list_depth == 0) {
+                        HTMLElement* sp = result_add(&result);
+                        sp->type = HELEM_TEXT;
+                        sp->text = strdup("\n\n");
+                    }
+                }
+                p = after;
+                continue;
+            }
+
+            // <li>
+            if (tag_eq(tag.name, tag.name_len, "li")) {
+                if (!tag.is_closing) {
+                    if (state.list_depth > 0) {
+                        flush_text(&result, &text_buf, state.cur_style);
+                        buf_free(&state.li_buf);
+                        buf_init(&state.li_buf);
+                        state.in_li = 1;
+                    } else {
+                        flush_text(&result, &text_buf, state.cur_style);
+                    }
+                } else if (state.in_li) {
+                    state.in_li = 0;
+                    flush_text(&result, &text_buf, state.cur_style);
+                    HTMLElement* e = result_add(&result);
+                    e->type = HELEM_LIST_ITEM;
+                    e->text = buf_finish(&state.li_buf);
+                    buf_init(&state.li_buf);
+                    char depth_buf[16];
+                    snprintf(depth_buf, sizeof(depth_buf), "%d", state.list_depth - 1);
+                    e->attr1 = strdup(depth_buf);
+                    if (state.list_depth > 0 &&
+                        state.list_ordered[state.list_depth - 1]) {
+                        char idx_buf[16];
+                        snprintf(idx_buf, sizeof(idx_buf), "%d",
+                                 state.list_index[state.list_depth - 1]);
+                        e->attr2 = strdup(idx_buf);
+                        state.list_index[state.list_depth - 1]++;
+                    }
+                }
+                p = after;
+                continue;
+            }
+
+            // Inline text formatting: <b>, <strong>, <i>, <em>, <u>, <s>, <del>
+            if (tag_eq(tag.name, tag.name_len, "b") ||
+                tag_eq(tag.name, tag.name_len, "strong") ||
+                tag_eq(tag.name, tag.name_len, "i") ||
+                tag_eq(tag.name, tag.name_len, "em") ||
+                tag_eq(tag.name, tag.name_len, "u") ||
+                tag_eq(tag.name, tag.name_len, "s") ||
+                tag_eq(tag.name, tag.name_len, "del")) {
+                int mask = 0;
+                if (tag_eq(tag.name, tag.name_len, "b") ||
+                    tag_eq(tag.name, tag.name_len, "strong"))
+                    mask = HTML_STYLE_BOLD;
+                else if (tag_eq(tag.name, tag.name_len, "i") ||
+                         tag_eq(tag.name, tag.name_len, "em"))
+                    mask = HTML_STYLE_ITALIC;
+                else if (tag_eq(tag.name, tag.name_len, "u"))
+                    mask = HTML_STYLE_UNDERLINE;
+                else
+                    mask = HTML_STYLE_STRIKETHROUGH;
+                // Flush pending text with the current style before it changes,
+                // so each styled span is emitted as its own TEXT element.
+                // Only when the main text_buf is the active target.
+                if (state.pre_depth == 0 && !state.in_td && !state.in_a &&
+                    state.h_level == 0 && state.bq_depth == 0 && !state.in_li) {
+                    if (text_buf.len > 0) {
+                        char last = text_buf.data[text_buf.len - 1];
+                        if (last != ' ' && last != '\n')
+                            state.pending_space = 1;
+                    }
+                    flush_text(&result, &text_buf, state.cur_style);
+                }
+                if (!tag.is_closing) {
+                    if (state.style_depth < MAX_STACK) {
+                        state.style_stack[state.style_depth++] = mask;
+                        state.cur_style |= mask;
+                    }
+                } else if (state.style_depth > 0) {
+                    state.style_depth--;
+                    int old = state.style_stack[state.style_depth];
+                    state.cur_style &= ~old;
+                }
+                p = after;
+                continue;
+            }
+
             // Block elements: add spacing
             if (tag_eq(tag.name, tag.name_len, "p") ||
-                tag_eq(tag.name, tag.name_len, "div") ||
-                tag_eq(tag.name, tag.name_len, "li") ||
-                tag_eq(tag.name, tag.name_len, "hr")) {
-                if (tag.is_closing || tag_eq(tag.name, tag.name_len, "hr")) {
+                tag_eq(tag.name, tag.name_len, "div")) {
+                if (tag.is_closing) {
                     if (state.pre_depth > 0) {
-                        // Preserve whitespace inside <pre>
                         buf_append_char(&state.pre_buf, '\n');
+                    } else if (state.in_li) {
+                        buf_append_char(&state.li_buf, '\n');
                     } else if (state.bq_depth > 0) {
                         buf_append(&state.bq_text, "\n\n", 2);
                     } else if (state.in_td) {
@@ -761,7 +910,7 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
                 continue;
             }
 
-            // <ul>, <ol>, <dl>, etc. - skip tag but process children
+            // <dl>, etc. - skip tag but process children
             p = after;
             continue;
         }
@@ -778,7 +927,8 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
             if (state.pre_depth > 0) target = &state.pre_buf;
             else if (state.in_td) target = &state.cell_text;
             else if (state.in_a) target = &state.a_text;
-            else if (state.in_h1 || state.in_h2) target = &state.h_text;
+            else if (state.h_level > 0) target = &state.h_text;
+            else if (state.in_li) target = &state.li_buf;
             else if (state.bq_depth > 0) target = &state.bq_text;
             else target = &text_buf;
 
@@ -789,15 +939,29 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
 
         // Regular character — collapse whitespace like HTML (unless in <pre>)
         char c = *p++;
+        // Preserve a single leading space that followed a styled span flush.
+        if (state.pending_space) {
+            state.pending_space = 0;
+            if ((c == ' ' || c == '\n' || c == '\r' || c == '\t') &&
+                state.pre_depth == 0 && !state.in_td && !state.in_a &&
+                state.h_level == 0 && state.bq_depth == 0 && !state.in_li &&
+                text_buf.len == 0) {
+                buf_append_char(&text_buf, ' ');
+                if (c == ' ' || c == '\n' || c == '\r' || c == '\t') {
+                    continue;
+                }
+            }
+        }
         if (state.pre_depth > 0) {
-            // Inside <pre>: preserve whitespace exactly.
             buf_append_char(&state.pre_buf, c);
         } else if (state.in_td) {
             buf_append_html_char(&state.cell_text, c, state.in_pre);
         } else if (state.in_a) {
             buf_append_html_char(&state.a_text, c, state.in_pre);
-        } else if (state.in_h1 || state.in_h2) {
+        } else if (state.h_level > 0) {
             buf_append_html_char(&state.h_text, c, state.in_pre);
+        } else if (state.in_li) {
+            buf_append_html_char(&state.li_buf, c, state.in_pre);
         } else if (state.bq_depth > 0) {
             buf_append_html_char(&state.bq_text, c, state.in_pre);
         } else {
@@ -806,15 +970,42 @@ HTMLConvertResult html_to_elements(const char* html, size_t len) {
     }
 
     // Flush remaining text
-    flush_text(&result, &text_buf);
+    flush_text(&result, &text_buf, state.cur_style);
 
     // Flush any unclosed elements
-    if (state.in_h1 || state.in_h2) {
+    if (state.h_level > 0) {
         HTMLElement* e = result_add(&result);
-        e->type = state.in_h1 ? HELEM_H1 : HELEM_H2;
+        switch (state.h_level) {
+            case 1: e->type = HELEM_H1; break;
+            case 2: e->type = HELEM_H2; break;
+            case 3: e->type = HELEM_H3; break;
+            case 4: e->type = HELEM_H4; break;
+            case 5: e->type = HELEM_H5; break;
+            case 6: e->type = HELEM_H6; break;
+            default: e->type = HELEM_H6; break;
+        }
         e->text = buf_finish(&state.h_text);
     } else {
         buf_free(&state.h_text);
+    }
+
+    if (state.in_li) {
+        state.in_li = 0;
+        HTMLElement* e = result_add(&result);
+        e->type = HELEM_LIST_ITEM;
+        e->text = buf_finish(&state.li_buf);
+        char depth_buf[16];
+        snprintf(depth_buf, sizeof(depth_buf), "%d", state.list_depth - 1);
+        e->attr1 = strdup(depth_buf);
+        if (state.list_depth > 0 &&
+            state.list_ordered[state.list_depth - 1]) {
+            char idx_buf[16];
+            snprintf(idx_buf, sizeof(idx_buf), "%d",
+                     state.list_index[state.list_depth - 1]);
+            e->attr2 = strdup(idx_buf);
+        }
+    } else {
+        buf_free(&state.li_buf);
     }
 
     if (state.in_a) {

--- a/clib/htmlconv.go
+++ b/clib/htmlconv.go
@@ -38,7 +38,8 @@ func HTMLToElements(html string) ([]HTMLElement, bool) {
 	for i := 0; i < count; i++ {
 		ce := &cElems[i]
 		elements[i] = HTMLElement{
-			Type: int(ce._type),
+			Type:  int(ce._type),
+			Style: int(ce.style),
 		}
 		if ce.text != nil {
 			elements[i].Text = C.GoString(ce.text)

--- a/clib/htmlconv.h
+++ b/clib/htmlconv.h
@@ -11,11 +11,23 @@ enum {
     HELEM_IMAGE      = 4,
     HELEM_BLOCKQUOTE = 5,
     HELEM_TABLE      = 6,
-    HELEM_CODE       = 7,  // Pre-formatted code block; attr1 holds the language hint
+    HELEM_CODE       = 7,
+    HELEM_H3         = 8,
+    HELEM_H4         = 9,
+    HELEM_H5         = 10,
+    HELEM_H6         = 11,
+    HELEM_LIST_ITEM  = 12,
+    HELEM_HR         = 13,
 };
+
+#define HTML_STYLE_BOLD          0x01
+#define HTML_STYLE_ITALIC        0x02
+#define HTML_STYLE_UNDERLINE     0x04
+#define HTML_STYLE_STRIKETHROUGH 0x08
 
 typedef struct {
     int type;
+    int style;
     char* text;
     char* attr1;
     char* attr2;

--- a/clib/htmlconv_nocgo.go
+++ b/clib/htmlconv_nocgo.go
@@ -8,15 +8,16 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
 )
 
 // HTMLToElements parses HTML and returns structured elements (pure Go fallback).
-func HTMLToElements(html string) ([]HTMLElement, bool) {
-	if len(html) == 0 {
+func HTMLToElements(htmlStr string) ([]HTMLElement, bool) {
+	if len(htmlStr) == 0 {
 		return nil, true
 	}
 
-	doc, err := goquery.NewDocumentFromReader(bytes.NewReader([]byte(html)))
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader([]byte(htmlStr)))
 	if err != nil {
 		return nil, false
 	}
@@ -25,30 +26,54 @@ func HTMLToElements(html string) ([]HTMLElement, bool) {
 
 	var elements []HTMLElement
 
-	// Process h1 elements
-	doc.Find("h1").Each(func(i int, s *goquery.Selection) {
-		elements = append(elements, HTMLElement{Type: HElemH1, Text: s.Text()})
+	headingTypes := map[string]int{
+		"h1": HElemH1, "h2": HElemH2, "h3": HElemH3,
+		"h4": HElemH4, "h5": HElemH5, "h6": HElemH6,
+	}
+	for tag, etype := range headingTypes {
+		t := etype
+		doc.Find(tag).Each(func(i int, s *goquery.Selection) {
+			elements = append(elements, HTMLElement{Type: t, Text: s.Text()})
+			s.ReplaceWithHtml("\n\n")
+		})
+	}
+
+	doc.Find("hr").Each(func(i int, s *goquery.Selection) {
+		elements = append(elements, HTMLElement{Type: HElemHR, Text: ""})
 		s.ReplaceWithHtml("\n\n")
 	})
 
-	// Process h2 elements
-	doc.Find("h2").Each(func(i int, s *goquery.Selection) {
-		elements = append(elements, HTMLElement{Type: HElemH2, Text: s.Text()})
+	doc.Find("li").Each(func(i int, s *goquery.Selection) {
+		depth := s.Parents().Filter("ul,ol").Length() - 1
+		if depth < 0 {
+			depth = 0
+		}
+		elem := HTMLElement{
+			Type:  HElemListItem,
+			Text:  s.Text(),
+			Attr1: itoa(depth),
+		}
+		if parent := s.Parent(); parent.Length() > 0 {
+			if goquery.NodeName(parent) == "ol" {
+				idx := s.PrevAll().Filter("li").Length() + 1
+				elem.Attr2 = itoa(idx)
+			}
+		}
+		elements = append(elements, elem)
+		s.ReplaceWithHtml("\n")
+	})
+	doc.Find("ul,ol").Each(func(i int, s *goquery.Selection) {
 		s.ReplaceWithHtml("\n\n")
 	})
 
-	// Add newlines after block elements
 	doc.Find("p, div").Each(func(i int, s *goquery.Selection) {
 		s.After("\n\n")
 	})
 
-	// Replace <br> with newlines
 	doc.Find("br").Each(func(i int, s *goquery.Selection) {
 		s.ReplaceWithHtml("\n")
 	})
 
-	// Process <pre> blocks — emit HELEM_CODE with optional language hint.
-	// md4c renders fenced code blocks as <pre><code class="language-X">.
 	doc.Find("pre").Each(func(i int, s *goquery.Selection) {
 		var lang string
 		if code := s.Find("code"); code.Length() > 0 {
@@ -70,7 +95,6 @@ func HTMLToElements(html string) ([]HTMLElement, bool) {
 		s.ReplaceWithHtml("\n\n")
 	})
 
-	// Process blockquotes
 	onWroteRegex := regexp.MustCompile(`On\s+(.+?),\s+(.+?)\s+wrote:`)
 	doc.Find("blockquote").Each(func(i int, s *goquery.Selection) {
 		cite, _ := s.Attr("cite")
@@ -98,7 +122,6 @@ func HTMLToElements(html string) ([]HTMLElement, bool) {
 		s.ReplaceWithHtml("\n")
 	})
 
-	// Process links
 	doc.Find("a").Each(func(i int, s *goquery.Selection) {
 		href, exists := s.Attr("href")
 		if !exists {
@@ -112,7 +135,6 @@ func HTMLToElements(html string) ([]HTMLElement, bool) {
 		s.ReplaceWithHtml("")
 	})
 
-	// Process images
 	doc.Find("img").Each(func(i int, s *goquery.Selection) {
 		src, exists := s.Attr("src")
 		if !exists {
@@ -130,13 +152,65 @@ func HTMLToElements(html string) ([]HTMLElement, bool) {
 		s.ReplaceWithHtml("")
 	})
 
-	// Get remaining text
-	text := doc.Text()
-	if strings.TrimSpace(text) != "" {
-		elements = append(elements, HTMLElement{Type: HElemText, Text: text})
-	}
+	walkInline(doc.Find("body"), 0, &elements)
 
 	return elements, true
+}
+
+var inlineStyleTags = map[string]int{
+	"b":      HTMLStyleBold,
+	"strong": HTMLStyleBold,
+	"i":      HTMLStyleItalic,
+	"em":     HTMLStyleItalic,
+	"u":      HTMLStyleUnderline,
+	"s":      HTMLStyleStrikethrough,
+	"del":    HTMLStyleStrikethrough,
+}
+
+func walkInline(sel *goquery.Selection, style int, out *[]HTMLElement) {
+	sel.Contents().Each(func(i int, s *goquery.Selection) {
+		node := s.Get(0)
+		if node == nil {
+			return
+		}
+		if node.Type == html.TextNode {
+			txt := node.Data
+			if strings.TrimSpace(txt) != "" {
+				*out = append(*out, HTMLElement{Type: HElemText, Style: style, Text: txt})
+			}
+			return
+		}
+		if node.Type == html.ElementNode {
+			name := strings.ToLower(goquery.NodeName(s))
+			if mask, ok := inlineStyleTags[name]; ok {
+				walkInline(s, style|mask, out)
+				return
+			}
+			walkInline(s, style, out)
+		}
+	})
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
 }
 
 // extractLanguageClass parses a class attribute value and returns the

--- a/clib/types.go
+++ b/clib/types.go
@@ -17,12 +17,26 @@ const (
 	HElemBlockquote = 5
 	HElemTable      = 6
 	HElemCode       = 7
+	HElemH3         = 8
+	HElemH4         = 9
+	HElemH5         = 10
+	HElemH6         = 11
+	HElemListItem   = 12
+	HElemHR         = 13
+)
+
+const (
+	HTMLStyleBold          = 0x01
+	HTMLStyleItalic        = 0x02
+	HTMLStyleUnderline     = 0x04
+	HTMLStyleStrikethrough = 0x08
 )
 
 // HTMLElement represents a parsed element from an HTML document.
 type HTMLElement struct {
 	Type  int
-	Text  string // Text content
-	Attr1 string // href (link), src (image), cite (blockquote)
-	Attr2 string // alt (image), prev_text (blockquote)
+	Style int
+	Text  string
+	Attr1 string
+	Attr2 string
 }

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.2
 	github.com/zalando/go-keyring v0.2.8
 	go.mozilla.org/pkcs7 v0.9.0
+	golang.org/x/net v0.55.0
 	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
 )
@@ -76,7 +77,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/image v0.41.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/internal/htmlsanitizer/lib_sanitizer.go
+++ b/internal/htmlsanitizer/lib_sanitizer.go
@@ -27,9 +27,9 @@ func newPolicy() *bluemonday.Policy {
 	dataImagePrefixPattern := regexp.MustCompile(`(?i)^image/(gif|jpe?g|png|webp);base64,`)
 	langClassPattern := regexp.MustCompile(`(?i)^language-[a-z0-9+#.]+$`)
 	p.AllowElements(
-		"a", "b", "blockquote", "br", "code", "div", "em", "h1", "h2",
-		"i", "img", "li", "ol", "p", "pre", "span", "strong", "table",
-		"tbody", "td", "th", "thead", "tr", "u", "ul",
+		"a", "b", "blockquote", "br", "code", "del", "div", "em", "h1", "h2",
+		"h3", "h4", "h5", "h6", "hr", "i", "img", "li", "ol", "p", "pre", "s",
+		"span", "strong", "table", "tbody", "td", "th", "thead", "tr", "u", "ul",
 	)
 	p.AllowAttrs("href").Matching(linkURLPattern).OnElements("a")
 	p.AllowAttrs("src").Matching(imageURLPattern).OnElements("img")

--- a/internal/htmlsanitizer/lib_sanitizer_test.go
+++ b/internal/htmlsanitizer/lib_sanitizer_test.go
@@ -307,3 +307,20 @@ func TestLibSanitizerRejectsInvalidDataImages(t *testing.T) {
 		t.Fatalf("sanitized HTML should keep valid unpadded png data URI:\n%s", got)
 	}
 }
+
+func TestLibSanitizerKeepsNewElements(t *testing.T) {
+	sanitizer := NewLibSanitizer()
+	input := []byte(`<h3>H3</h3><h4>H4</h4><h5>H5</h5><h6>H6</h6><hr><ul><li>item</li></ul><ol><li>one</li></ol><b>b</b><strong>s</strong><i>i</i><em>e</em><u>u</u><s>st</s><del>d</del>`)
+
+	got := string(sanitizer.SanitizeBytes(input))
+
+	for _, want := range []string{
+		"<h3>", "<h4>", "<h5>", "<h6>", "<hr",
+		"<ul>", "<ol>", "<li>",
+		"<b>", "<strong>", "<i>", "<em>", "<u>", "<s>", "<del>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("sanitizer stripped %q\nGot: %s", want, got)
+		}
+	}
+}

--- a/view/html.go
+++ b/view/html.go
@@ -680,6 +680,12 @@ func processBody(rawBody, mimeType string, inline map[string]string, h1Style, h2
 	return bodyStyle.Render(result), placements, nil
 }
 
+type pendingImage struct {
+	index   int
+	encoded string
+	rows    int
+}
+
 func renderHTMLToText(htmlBody []byte, inline map[string]string, h1Style, h2Style lipgloss.Style, disableImages bool) (string, []ImagePlacement, error) {
 	// Parse HTML into structured elements using C parser.
 	elements, ok := clib.HTMLToElements(string(htmlBody))
@@ -690,11 +696,7 @@ func renderHTMLToText(htmlBody []byte, inline map[string]string, h1Style, h2Styl
 	// Process elements: apply styles and collect image placements.
 	var text strings.Builder
 	var imgIndex int
-	var pendingImages []struct {
-		index   int
-		encoded string
-		rows    int
-	}
+	var pendingImages []pendingImage
 
 	onWroteRegex := regexp.MustCompile(`On\s+(.+?),\s+(.+?)\s+wrote:`)
 
@@ -735,42 +737,7 @@ func renderHTMLToText(htmlBody []byte, inline map[string]string, h1Style, h2Styl
 			}
 
 		case clib.HElemImage:
-			src := strings.TrimSpace(elem.Attr1)
-			alt := stripTerminalControls(elem.Attr2)
-			if hasTerminalControls(src) {
-				continue
-			}
-
-			if !disableImages && imageProtocolSupported() {
-				payload := resolveImagePayload(src, inline)
-
-				if payload != "" {
-					encoded, rows := prerenderImage(payload)
-					if encoded == "" {
-						debugImageProtocol("prerender failed for src=%s", src)
-					} else {
-						debugImageProtocol("collected image placement src=%s rows=%d", src, rows)
-
-						idx := imgIndex
-						imgIndex++
-						pendingImages = append(pendingImages, struct {
-							index   int
-							encoded string
-							rows    int
-						}{idx, encoded, rows})
-
-						fmt.Fprintf(&text, "\n[[MATCHA_IMG:%d]]", idx)
-						fmt.Fprintf(&text, "\n%s%d%s\n", imageRowPlaceholderPrefix, rows, imageRowPlaceholderSuffix)
-						continue
-					}
-				}
-				debugImageProtocol("no payload for src=%s", src)
-			}
-			if isRemoteImageURL(src) && hyperlinkSupported() {
-				fmt.Fprintf(&text, "\n %s \n", hyperlink(src, fmt.Sprintf("[Click here to view image: %s]", alt)))
-			} else {
-				fmt.Fprintf(&text, "\n %s \n", linkStyle().Render(fmt.Sprintf("[Image: %s, %s]", alt, src)))
-			}
+			renderImageElement(&text, &imgIndex, &pendingImages, elem, inline, disableImages)
 
 		case clib.HElemTable:
 			headerRows := 0
@@ -816,33 +783,75 @@ func renderHTMLToText(htmlBody []byte, inline map[string]string, h1Style, h2Styl
 	// Now expand the image row placeholders to actual newlines
 	result = expandImageRowPlaceholders(result)
 
-	// Build image placements by finding the line numbers of image markers.
+	placements, result := buildImagePlacements(result, pendingImages)
+
+	return result, placements, nil
+}
+
+func renderImageElement(text *strings.Builder, imgIndex *int, pendingImages *[]pendingImage, elem clib.HTMLElement, inline map[string]string, disableImages bool) {
+	src := strings.TrimSpace(elem.Attr1)
+	alt := stripTerminalControls(elem.Attr2)
+	if hasTerminalControls(src) {
+		return
+	}
+
+	if !disableImages && imageProtocolSupported() {
+		payload := resolveImagePayload(src, inline)
+
+		if payload != "" {
+			encoded, rows := prerenderImage(payload)
+			if encoded == "" {
+				debugImageProtocol("prerender failed for src=%s", src)
+			} else {
+				debugImageProtocol("collected image placement src=%s rows=%d", src, rows)
+
+				idx := *imgIndex
+				*imgIndex++
+				*pendingImages = append(*pendingImages, pendingImage{idx, encoded, rows})
+
+				fmt.Fprintf(text, "\n[[MATCHA_IMG:%d]]", idx)
+				fmt.Fprintf(text, "\n%s%d%s\n", imageRowPlaceholderPrefix, rows, imageRowPlaceholderSuffix)
+				return
+			}
+		}
+		debugImageProtocol("no payload for src=%s", src)
+	}
+	if isRemoteImageURL(src) && hyperlinkSupported() {
+		fmt.Fprintf(text, "\n %s \n", hyperlink(src, fmt.Sprintf("[Click here to view image: %s]", alt)))
+	} else {
+		fmt.Fprintf(text, "\n %s \n", linkStyle().Render(fmt.Sprintf("[Image: %s, %s]", alt, src)))
+	}
+}
+
+func buildImagePlacements(result string, pendingImages []pendingImage) ([]ImagePlacement, string) {
+	if len(pendingImages) == 0 {
+		return nil, result
+	}
+
 	var placements []ImagePlacement
-	if len(pendingImages) > 0 {
-		lines := strings.Split(result, "\n")
-		imgMarkerRegex := regexp.MustCompile(`\[\[MATCHA_IMG:(\d+)\]\]`)
-		for lineNum, line := range lines {
-			if matches := imgMarkerRegex.FindStringSubmatch(line); matches != nil {
-				var idx int
-				fmt.Sscanf(matches[1], "%d", &idx) //nolint:errcheck,gosec
-				for _, pi := range pendingImages {
-					if pi.index == idx {
-						placements = append(placements, ImagePlacement{
-							Line:    lineNum,
-							Encoded: pi.encoded,
-							Rows:    pi.rows,
-						})
-						break
-					}
+	lines := strings.Split(result, "\n")
+	imgMarkerRegex := regexp.MustCompile(`\[\[MATCHA_IMG:(\d+)\]\]`)
+	for lineNum, line := range lines {
+		if matches := imgMarkerRegex.FindStringSubmatch(line); matches != nil {
+			var idx int
+			fmt.Sscanf(matches[1], "%d", &idx) //nolint:errcheck,gosec
+			for _, pi := range pendingImages {
+				if pi.index == idx {
+					placements = append(placements, ImagePlacement{
+						Line:    lineNum,
+						Encoded: pi.encoded,
+						Rows:    pi.rows,
+					})
+					break
 				}
 			}
 		}
-
-		// Remove the image markers from the text (leave the spacing)
-		result = imgMarkerRegex.ReplaceAllString(result, "")
 	}
 
-	return result, placements, nil
+	// Remove the image markers from the text (leave the spacing)
+	result = imgMarkerRegex.ReplaceAllString(result, "")
+
+	return placements, result
 }
 
 func resolveImagePayload(src string, inline map[string]string) string {

--- a/view/html.go
+++ b/view/html.go
@@ -8,6 +8,7 @@ import (
 	"mime/quotedprintable"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +29,92 @@ const termGhostty = "ghostty"
 
 func linkStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(theme.ActiveTheme.Link)
+}
+
+func h3Style() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(theme.ActiveTheme.Accent).
+		Bold(true)
+}
+
+func h4Style() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(theme.ActiveTheme.Accent).
+		Bold(false)
+}
+
+func h5Style() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(theme.ActiveTheme.Secondary).
+		Bold(true)
+}
+
+func h6Style() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(theme.ActiveTheme.Secondary).
+		Bold(false).
+		Italic(true)
+}
+
+func hrStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.ActiveTheme.Secondary)
+}
+
+func renderStyledText(s string, style int) string {
+	if style == 0 || strings.TrimSpace(s) == "" {
+		return s
+	}
+	st := lipgloss.NewStyle()
+	if style&clib.HTMLStyleBold != 0 {
+		st = st.Bold(true)
+	}
+	if style&clib.HTMLStyleItalic != 0 {
+		st = st.Italic(true)
+	}
+	if style&clib.HTMLStyleUnderline != 0 {
+		st = st.Underline(true)
+	}
+	if style&clib.HTMLStyleStrikethrough != 0 {
+		st = st.Strikethrough(true)
+	}
+	return st.Render(s)
+}
+
+func renderListItem(itemText, depthStr, indexStr string) string {
+	depth := 0
+	if d, err := strconv.Atoi(depthStr); err == nil {
+		depth = d
+	}
+	if depth < 0 {
+		depth = 0
+	}
+	indent := strings.Repeat("  ", depth)
+	var marker string
+	if indexStr != "" {
+		marker = indexStr + ". "
+	} else {
+		marker = "• "
+	}
+	lines := strings.Split(strings.TrimSpace(itemText), "\n")
+	for i, line := range lines {
+		if i == 0 {
+			lines[i] = indent + marker + line
+		} else {
+			lines[i] = indent + strings.Repeat(" ", len(marker)) + line
+		}
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func renderHR() string {
+	width := 40
+	if cols, _, ok := getTerminalSize(); ok && cols > 0 {
+		width = cols
+	}
+	if width > 60 {
+		width = 60
+	}
+	return "\n" + hrStyle().Render(strings.Repeat("─", width)) + "\n"
 }
 
 // hyperlinkSupported checks if the terminal supports OSC 8 hyperlinks.
@@ -614,7 +701,7 @@ func renderHTMLToText(htmlBody []byte, inline map[string]string, h1Style, h2Styl
 	for _, elem := range elements {
 		switch elem.Type {
 		case clib.HElemText:
-			text.WriteString(elem.Text)
+			text.WriteString(renderStyledText(elem.Text, elem.Style))
 
 		case clib.HElemH1:
 			text.WriteString(h1Style.Render(elem.Text))
@@ -622,6 +709,22 @@ func renderHTMLToText(htmlBody []byte, inline map[string]string, h1Style, h2Styl
 
 		case clib.HElemH2:
 			text.WriteString(h2Style.Render(elem.Text))
+			text.WriteString("\n\n")
+
+		case clib.HElemH3:
+			text.WriteString(h3Style().Render(elem.Text))
+			text.WriteString("\n\n")
+
+		case clib.HElemH4:
+			text.WriteString(h4Style().Render(elem.Text))
+			text.WriteString("\n\n")
+
+		case clib.HElemH5:
+			text.WriteString(h5Style().Render(elem.Text))
+			text.WriteString("\n\n")
+
+		case clib.HElemH6:
+			text.WriteString(h6Style().Render(elem.Text))
 			text.WriteString("\n\n")
 
 		case clib.HElemLink:
@@ -695,6 +798,12 @@ func renderHTMLToText(htmlBody []byte, inline map[string]string, h1Style, h2Styl
 
 		case clib.HElemCode:
 			text.WriteString(renderCodeBlock(elem.Text, elem.Attr1))
+
+		case clib.HElemListItem:
+			text.WriteString(renderListItem(elem.Text, elem.Attr1, elem.Attr2))
+
+		case clib.HElemHR:
+			text.WriteString(renderHR())
 		}
 	}
 

--- a/view/html_test.go
+++ b/view/html_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/floatpane/matcha/clib"
 )
 
 // clearAllTerminalEnv clears all environment variables that could indicate terminal capabilities
@@ -1117,5 +1118,315 @@ func TestRemoteImageCache_EvictsOldestWhenFull(t *testing.T) {
 		if _, ok := remoteImageCache.Get(keptURL); !ok {
 			t.Errorf("expected %q to still be in cache", keptURL)
 		}
+	}
+}
+
+func TestProcessBodyListsAndHR(t *testing.T) {
+	origTerm := os.Getenv("TERM")
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	defer func() {
+		os.Setenv("TERM", origTerm)
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+	}()
+	os.Setenv("TERM", "xterm")
+	os.Setenv("TERM_PROGRAM", "")
+
+	h1Style := lipgloss.NewStyle()
+	h2Style := lipgloss.NewStyle()
+	bodyStyle := lipgloss.NewStyle()
+
+	ansiEscapeRegex := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+	tests := []struct {
+		name           string
+		input          string
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:  "unordered list with bullets",
+			input: `<ul><li>Apple</li><li>Banana</li></ul>`,
+			wantContains: []string{
+				"• Apple",
+				"• Banana",
+			},
+		},
+		{
+			name:  "ordered list with numeric indices",
+			input: `<ol><li>First</li><li>Second</li><li>Third</li></ol>`,
+			wantContains: []string{
+				"1. First",
+				"2. Second",
+				"3. Third",
+			},
+		},
+		{
+			name:  "nested list indentation",
+			input: `<ul><li>Outer<ul><li>Inner</li></ul></li></ul>`,
+			wantContains: []string{
+				"• Outer",
+				"  • Inner",
+			},
+		},
+		{
+			name:         "horizontal rule renders divider",
+			input:        `<p>Before</p><hr><p>After</p>`,
+			wantContains: []string{"Before", "After", "─"},
+		},
+		{
+			name:           "li content is preserved",
+			input:          `<ul><li>Item with text</li></ul>`,
+			wantContains:   []string{"Item with text"},
+			wantNotContain: []string{"<li>"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processed, _, err := ProcessBody(tt.input, BodyMIMETypeHTML, h1Style, h2Style, bodyStyle, true)
+			if err != nil {
+				t.Fatalf("ProcessBody() failed: %v", err)
+			}
+			clean := ansiEscapeRegex.ReplaceAllString(processed, "")
+			for _, want := range tt.wantContains {
+				if !strings.Contains(clean, want) {
+					t.Errorf("processed body missing %q\nGot: %q", want, clean)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(clean, notWant) {
+					t.Errorf("processed body should not contain %q\nGot: %q", notWant, clean)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessBodyHeadings(t *testing.T) {
+	origTerm := os.Getenv("TERM")
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	defer func() {
+		os.Setenv("TERM", origTerm)
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+	}()
+	os.Setenv("TERM", "xterm")
+	os.Setenv("TERM_PROGRAM", "")
+
+	h1Style := lipgloss.NewStyle()
+	h2Style := lipgloss.NewStyle()
+	bodyStyle := lipgloss.NewStyle()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"h3", `<h3>Subheading Three</h3>`, "Subheading Three"},
+		{"h4", `<h4>Subheading Four</h4>`, "Subheading Four"},
+		{"h5", `<h5>Subheading Five</h5>`, "Subheading Five"},
+		{"h6", `<h6>Subheading Six</h6>`, "Subheading Six"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processed, _, err := ProcessBody(tt.input, BodyMIMETypeHTML, h1Style, h2Style, bodyStyle, true)
+			if err != nil {
+				t.Fatalf("ProcessBody() failed: %v", err)
+			}
+			if !strings.Contains(processed, tt.want) {
+				t.Errorf("processed body missing %q\nGot: %q", tt.want, processed)
+			}
+		})
+	}
+}
+
+func TestProcessBodyInlineFormatting(t *testing.T) {
+	origTerm := os.Getenv("TERM")
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	defer func() {
+		os.Setenv("TERM", origTerm)
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+	}()
+	os.Setenv("TERM", "xterm")
+	os.Setenv("TERM_PROGRAM", "")
+
+	h1Style := lipgloss.NewStyle()
+	h2Style := lipgloss.NewStyle()
+	bodyStyle := lipgloss.NewStyle()
+
+	ansiEscapeRegex := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bold", `<b>bold text</b>`, "bold text"},
+		{"strong", `<strong>strong text</strong>`, "strong text"},
+		{"italic", `<i>italic text</i>`, "italic text"},
+		{"em", `<em>emphasized</em>`, "emphasized"},
+		{"underline", `<u>underlined</u>`, "underlined"},
+		{"strikethrough s", `<s>struck</s>`, "struck"},
+		{"strikethrough del", `<del>deleted</del>`, "deleted"},
+		{"nested bold+italic", `<b><i>both</i></b>`, "both"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processed, _, err := ProcessBody(tt.input, BodyMIMETypeHTML, h1Style, h2Style, bodyStyle, true)
+			if err != nil {
+				t.Fatalf("ProcessBody() failed: %v", err)
+			}
+			clean := ansiEscapeRegex.ReplaceAllString(processed, "")
+			if !strings.Contains(clean, tt.want) {
+				t.Errorf("processed body missing %q\nGot: %q", tt.want, clean)
+			}
+		})
+	}
+}
+
+func TestRenderListItem(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		depth    string
+		index    string
+		contains []string
+	}{
+		{"unordered", "Apple", "0", "", []string{"• Apple"}},
+		{"ordered first", "First", "0", "1", []string{"1. First"}},
+		{"ordered second", "Second", "0", "2", []string{"2. Second"}},
+		{"nested depth 1", "Inner", "1", "", []string{"  • Inner"}},
+		{"nested depth 2", "Deep", "2", "3", []string{"    3. Deep"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderListItem(tt.text, tt.depth, tt.index)
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("renderListItem(%q,%q,%q) = %q, missing %q", tt.text, tt.depth, tt.index, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderStyledText(t *testing.T) {
+	if got := renderStyledText("plain", 0); got != "plain" {
+		t.Errorf("renderStyledText plain = %q, want %q", got, "plain")
+	}
+	bold := renderStyledText("x", clib.HTMLStyleBold)
+	if !strings.Contains(bold, "x") {
+		t.Errorf("bold render lost text: %q", bold)
+	}
+	if !strings.Contains(bold, "\x1b[") {
+		t.Errorf("bold render missing ANSI codes: %q", bold)
+	}
+	combined := renderStyledText("y", clib.HTMLStyleBold|clib.HTMLStyleItalic|clib.HTMLStyleUnderline|clib.HTMLStyleStrikethrough)
+	if !strings.Contains(combined, "y") {
+		t.Errorf("combined render lost text: %q", combined)
+	}
+}
+
+func TestHTMLToElementsLists(t *testing.T) {
+	elements, ok := clib.HTMLToElements(`<ol><li>One</li><li>Two</li></ol>`)
+	if !ok {
+		t.Fatalf("HTMLToElements failed")
+	}
+	var items []clib.HTMLElement
+	for _, e := range elements {
+		if e.Type == clib.HElemListItem {
+			items = append(items, e)
+		}
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 list items, got %d", len(items))
+	}
+	if items[0].Text != "One" || items[1].Text != "Two" {
+		t.Errorf("list item text = %q, %q", items[0].Text, items[1].Text)
+	}
+	if items[0].Attr2 != "1" || items[1].Attr2 != "2" {
+		t.Errorf("ordered indices = %q, %q (want 1, 2)", items[0].Attr2, items[1].Attr2)
+	}
+}
+
+func TestHTMLToElementsUnorderedNoIndex(t *testing.T) {
+	elements, ok := clib.HTMLToElements(`<ul><li>A</li><li>B</li></ul>`)
+	if !ok {
+		t.Fatalf("HTMLToElements failed")
+	}
+	var items []clib.HTMLElement
+	for _, e := range elements {
+		if e.Type == clib.HElemListItem {
+			items = append(items, e)
+		}
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 list items, got %d", len(items))
+	}
+	for _, it := range items {
+		if it.Attr2 != "" {
+			t.Errorf("unordered item should have empty index, got %q", it.Attr2)
+		}
+	}
+}
+
+func TestHTMLToElementsHR(t *testing.T) {
+	elements, ok := clib.HTMLToElements(`<p>Before</p><hr><p>After</p>`)
+	if !ok {
+		t.Fatalf("HTMLToElements failed")
+	}
+	found := false
+	for _, e := range elements {
+		if e.Type == clib.HElemHR {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an HELEM_HR element")
+	}
+}
+
+func TestHTMLToElementsHeadings(t *testing.T) {
+	elements, ok := clib.HTMLToElements(`<h3>Title 3</h3><h6>Title 6</h6>`)
+	if !ok {
+		t.Fatalf("HTMLToElements failed")
+	}
+	wantTypes := map[int]bool{clib.HElemH3: false, clib.HElemH6: false}
+	for _, e := range elements {
+		if _, ok := wantTypes[e.Type]; ok {
+			wantTypes[e.Type] = true
+		}
+	}
+	for et, found := range wantTypes {
+		if !found {
+			t.Errorf("expected heading element type %d", et)
+		}
+	}
+}
+
+func TestHTMLToElementsInlineStyle(t *testing.T) {
+	elements, ok := clib.HTMLToElements(`<b>bold</b> and <i>italic</i>`)
+	if !ok {
+		t.Fatalf("HTMLToElements failed")
+	}
+	foundBold := false
+	foundItalic := false
+	for _, e := range elements {
+		if e.Type == clib.HElemText {
+			if e.Style&clib.HTMLStyleBold != 0 && strings.Contains(e.Text, "bold") {
+				foundBold = true
+			}
+			if e.Style&clib.HTMLStyleItalic != 0 && strings.Contains(e.Text, "italic") {
+				foundItalic = true
+			}
+		}
+	}
+	if !foundBold {
+		t.Errorf("expected a bold-styled TEXT element")
+	}
+	if !foundItalic {
+		t.Errorf("expected an italic-styled TEXT element")
 	}
 }


### PR DESCRIPTION
## What?

Adds support for `h3` - `h6`, lists (`ul`, `ol`, `li`), inline formatting (`b`, `strong`, `i`, `em`, `u`, `s`, `del`), as well as horizontal rules (`hr`)
 
## Why?

Adds more tags, so that the renderer parses more of the emails fully
