### PR TITLE
fix: daemon socket death

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1337,6 +1337,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 
 	case tui.DaemonEventMsg:
 		if msg.Event == nil {
+			// Events channel closed — daemon may have reconnected with a
+			// fresh channel. Re-subscribe if still in daemon mode.
+			if m.service != nil && m.service.IsDaemon() {
+				return m, idledaemon.ListenForDaemonEvents(m.service.Events())
+			}
 			return m, nil
 		}
 		var daemonCmds []tea.Cmd

--- a/daemonclient/client.go
+++ b/daemonclient/client.go
@@ -18,6 +18,7 @@ type Client struct {
 	mu      sync.Mutex
 	events  chan *daemonrpc.Event
 	done    chan struct{}
+	closeMu sync.Mutex // serializes close(done) between Close and readLoop
 }
 
 // Dial connects to the daemon socket.
@@ -97,12 +98,13 @@ func (c *Client) Events() <-chan *daemonrpc.Event {
 
 // Close closes the connection to the daemon.
 func (c *Client) Close() error {
+	c.closeMu.Lock()
 	select {
 	case <-c.done:
-		return nil
 	default:
 		close(c.done)
 	}
+	c.closeMu.Unlock()
 	return c.conn.Close()
 }
 
@@ -113,11 +115,13 @@ func (c *Client) readLoop() {
 	for {
 		msg, err := c.conn.ReceiveMessage()
 		if err != nil {
+			c.closeMu.Lock()
 			select {
 			case <-c.done:
 			default:
 				close(c.done)
 			}
+			c.closeMu.Unlock()
 			return
 		}
 

--- a/daemonclient/client_test.go
+++ b/daemonclient/client_test.go
@@ -2,8 +2,12 @@ package daemonclient
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/floatpane/matcha/daemonrpc"
 )
@@ -150,6 +154,189 @@ func TestClient_ConcurrentCalls(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		if err := <-errs; err != nil {
 			t.Errorf("call %d failed: %v", i, err)
+		}
+	}
+}
+
+// TestClient_CloseWhileReadLoopErrors hammers the race between Close() and
+// readLoop() detecting a connection error. Without closeMu, concurrent
+// close(done) panics ("close of closed channel").
+func TestClient_CloseWhileReadLoopErrors(t *testing.T) {
+	const iterations = 200
+	var panics atomic.Int32
+
+	for i := 0; i < iterations; i++ {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panics.Add(1)
+					t.Errorf("panic on iteration %d: %v", i, r)
+				}
+			}()
+
+			serverConn, clientConn := net.Pipe()
+			client := &Client{
+				conn:    daemonrpc.NewConn(clientConn),
+				pending: make(map[uint64]chan *daemonrpc.Response),
+				events:  make(chan *daemonrpc.Event, 64),
+				done:    make(chan struct{}),
+			}
+			go client.readLoop()
+
+			// Close the server side so readLoop's ReceiveMessage gets an
+			// error roughly at the same time as we call Close.
+			serverConn.Close()
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				_ = client.Close()
+			}()
+			go func() {
+				defer wg.Done()
+				// Give readLoop a chance to observe the error.
+				time.Sleep(time.Microsecond)
+				_ = client.Close()
+			}()
+			wg.Wait()
+		}()
+	}
+
+	if panics.Load() > 0 {
+		t.Fatalf("detected %d panics across %d iterations", panics.Load(), iterations)
+	}
+}
+
+// TestClient_CallAfterConnectionClosed verifies that Call returns
+// "connection closed" promptly after the socket dies, not "send request:
+// use of closed network connection".
+func TestClient_CallAfterConnectionClosed(t *testing.T) {
+	client, server := mockDaemon(t)
+
+	// Close the server side to simulate daemon death.
+	server.Close()
+
+	// Wait for readLoop to notice the error and close done.
+	<-client.done
+
+	// Now any Call should return "connection closed" quickly.
+	done := make(chan error, 1)
+	go func() {
+		done <- client.Call(daemonrpc.MethodPing, nil, nil)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error after connection closed")
+		}
+		// Should be "connection closed", not a hang or a send error.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Call hung after connection closed")
+	}
+}
+
+// TestDaemonService_Reconnect verifies that daemonService transparently
+// reconnects after the socket dies.
+func TestDaemonService_Reconnect(t *testing.T) {
+	// We can't use tryConnectWithConfig (it dials the real daemon), so
+	// we build the daemonService manually with a mock client.
+
+	// Create first connection pair (original daemon).
+	serverConn1, clientConn1 := net.Pipe()
+	server1 := daemonrpc.NewConn(serverConn1)
+	client1 := &Client{
+		conn:    daemonrpc.NewConn(clientConn1),
+		pending: make(map[uint64]chan *daemonrpc.Response),
+		events:  make(chan *daemonrpc.Event, 64),
+		done:    make(chan struct{}),
+	}
+	go client1.readLoop()
+
+	svc := &daemonService{
+		client: client1,
+	}
+
+	// Server1 responds to one Ping, then we kill it.
+	go func() {
+		msg, err := server1.ReceiveMessage()
+		if err != nil {
+			return
+		}
+		server1.SendResponse(msg.Request.ID, daemonrpc.PingResult{Pong: true})
+	}()
+
+	// First call succeeds.
+	if err := svc.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodPing, nil, nil)
+	}); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	// Kill the server side to simulate daemon crash.
+	server1.Close()
+	// Wait for readLoop to notice.
+	<-client1.done
+
+	// Now set up a "reconnected" daemon by replacing the client.
+	// We simulate a successful reconnect by directly swapping the client.
+	serverConn2, clientConn2 := net.Pipe()
+	server2 := daemonrpc.NewConn(serverConn2)
+	client2 := &Client{
+		conn:    daemonrpc.NewConn(clientConn2),
+		pending: make(map[uint64]chan *daemonrpc.Response),
+		events:  make(chan *daemonrpc.Event, 64),
+		done:    make(chan struct{}),
+	}
+	go client2.readLoop()
+
+	// Override reconnect to swap in client2.
+	svc.mu.Lock()
+	svc.client = client2
+	svc.mu.Unlock()
+
+	// Server2 responds to Ping.
+	go func() {
+		msg, err := server2.ReceiveMessage()
+		if err != nil {
+			return
+		}
+		server2.SendResponse(msg.Request.ID, daemonrpc.PingResult{Pong: true})
+	}()
+
+	// After reconnect, the call should succeed.
+	if err := svc.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodPing, nil, nil)
+	}); err != nil {
+		t.Fatalf("call after reconnect failed: %v", err)
+	}
+
+	svc.Close()
+	server2.Close()
+}
+
+// TestIsConnError verifies the error classification.
+func TestIsConnError(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{fmt.Errorf("connection closed"), true},
+		{fmt.Errorf("send request: use of closed network connection"), true},
+		{fmt.Errorf("write: broken pipe"), true},
+		{fmt.Errorf("unexpected EOF"), true},
+		{fmt.Errorf("connect to daemon: dial unix: no such file"), true},
+		{fmt.Errorf("method not found"), false},
+		{fmt.Errorf("no provider for account foo"), false},
+		{&daemonrpc.Error{Code: daemonrpc.ErrCodeNotFound, Message: "not found"}, false},
+	}
+
+	for _, tt := range tests {
+		got := isConnError(tt.err)
+		if got != tt.want {
+			t.Errorf("isConnError(%v) = %v, want %v", tt.err, got, tt.want)
 		}
 	}
 }

--- a/daemonclient/service.go
+++ b/daemonclient/service.go
@@ -141,12 +141,12 @@ func (s *daemonService) call(fn func(*Client) error) error {
 		s.mu.Lock()
 		client = s.client
 		s.mu.Unlock()
-		if err2 := fn(client); err2 == nil {
+		err2 := fn(client)
+		if err2 == nil {
 			loglevel.Debugf("service: reconnected to daemon successfully")
 			return nil
-		} else {
-			return err2
 		}
+		return err2
 	}
 
 	return err

--- a/daemonclient/service.go
+++ b/daemonclient/service.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/floatpane/matcha/backend"
@@ -51,7 +53,7 @@ func NewService(cfg *config.Config) Service {
 	}
 
 	// Try connecting to existing daemon.
-	if svc := tryConnect(); svc != nil {
+	if svc := tryConnectWithConfig(cfg); svc != nil {
 		return svc
 	}
 
@@ -65,7 +67,7 @@ func NewService(cfg *config.Config) Service {
 	// Wait briefly for daemon to become ready, then connect.
 	for i := 0; i < 20; i++ {
 		time.Sleep(100 * time.Millisecond)
-		if svc := tryConnect(); svc != nil {
+		if svc := tryConnectWithConfig(cfg); svc != nil {
 			loglevel.Debugf("service: connected to auto-started daemon")
 			return svc
 		}
@@ -75,7 +77,7 @@ func NewService(cfg *config.Config) Service {
 	return newDirectService(cfg)
 }
 
-func tryConnect() *daemonService {
+func tryConnectWithConfig(cfg *config.Config) *daemonService {
 	client, err := Dial()
 	if err != nil {
 		return nil
@@ -84,7 +86,7 @@ func tryConnect() *daemonService {
 		client.Close() //nolint:errcheck,gosec
 		return nil
 	}
-	return &daemonService{client: client}
+	return &daemonService{cfg: cfg, client: client}
 }
 
 func autoStartDaemon() error {
@@ -104,27 +106,118 @@ func autoStartDaemon() error {
 
 // daemonService routes all operations through the daemon socket.
 type daemonService struct {
+	cfg    *config.Config
 	client *Client
+	mu     sync.Mutex // guards client during reconnect
+}
+
+// call executes fn against the current client. If the call fails with a
+// connection-level error, it attempts to reconnect once and retries.
+func (s *daemonService) call(fn func(*Client) error) error {
+	s.mu.Lock()
+	client := s.client
+	s.mu.Unlock()
+
+	if client == nil {
+		if !s.reconnect() {
+			return fmt.Errorf("daemon connection lost and could not be re-established")
+		}
+		s.mu.Lock()
+		client = s.client
+		s.mu.Unlock()
+	}
+
+	err := fn(client)
+	if err == nil {
+		return nil
+	}
+
+	if !isConnError(err) {
+		return err
+	}
+
+	loglevel.Debugf("service: daemon connection lost (%v), attempting reconnect", err)
+	if s.reconnect() {
+		s.mu.Lock()
+		client = s.client
+		s.mu.Unlock()
+		if err2 := fn(client); err2 == nil {
+			loglevel.Debugf("service: reconnected to daemon successfully")
+			return nil
+		} else {
+			return err2
+		}
+	}
+
+	return err
+}
+
+// reconnect closes the old client and establishes a new connection,
+// auto-starting the daemon if necessary. Returns true on success.
+func (s *daemonService) reconnect() bool {
+	s.mu.Lock()
+	if s.client != nil {
+		s.client.Close() //nolint:errcheck,gosec
+		s.client = nil
+	}
+	s.mu.Unlock()
+
+	if svc := tryConnectWithConfig(s.cfg); svc != nil {
+		s.mu.Lock()
+		s.client = svc.client
+		s.mu.Unlock()
+		return true
+	}
+	return false
+}
+
+// isConnError reports whether err indicates a broken socket connection
+// rather than an application-level RPC error.
+func isConnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "connection closed") {
+		return true
+	}
+	if strings.Contains(msg, "use of closed network connection") {
+		return true
+	}
+	if strings.Contains(msg, "broken pipe") {
+		return true
+	}
+	if strings.Contains(msg, "EOF") {
+		return true
+	}
+	if strings.Contains(msg, "connect to daemon") {
+		return true
+	}
+	return false
 }
 
 func (s *daemonService) FetchEmails(accountID, folder string, limit, offset uint32) ([]backend.Email, error) {
 	var emails []backend.Email
-	err := s.client.Call(daemonrpc.MethodFetchEmails, daemonrpc.FetchEmailsParams{
-		AccountID: accountID,
-		Folder:    folder,
-		Limit:     limit,
-		Offset:    offset,
-	}, &emails)
+	err := s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodFetchEmails, daemonrpc.FetchEmailsParams{
+			AccountID: accountID,
+			Folder:    folder,
+			Limit:     limit,
+			Offset:    offset,
+		}, &emails)
+	})
 	return emails, err
 }
 
 func (s *daemonService) FetchEmailBody(accountID, folder string, uid uint32) (string, string, []backend.Attachment, error) {
 	var result daemonrpc.FetchEmailBodyResult
-	err := s.client.Call(daemonrpc.MethodFetchEmailBody, daemonrpc.FetchEmailBodyParams{
-		AccountID: accountID,
-		Folder:    folder,
-		UID:       uid,
-	}, &result)
+	err := s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodFetchEmailBody, daemonrpc.FetchEmailBodyParams{
+			AccountID: accountID,
+			Folder:    folder,
+			UID:       uid,
+		}, &result)
+	})
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -142,121 +235,157 @@ func (s *daemonService) FetchEmailBody(accountID, folder string, uid uint32) (st
 }
 
 func (s *daemonService) DeleteEmails(accountID, folder string, uids []uint32) error {
-	return s.client.Call(daemonrpc.MethodDeleteEmails, daemonrpc.DeleteEmailsParams{
-		AccountID: accountID,
-		Folder:    folder,
-		UIDs:      uids,
-	}, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodDeleteEmails, daemonrpc.DeleteEmailsParams{
+			AccountID: accountID,
+			Folder:    folder,
+			UIDs:      uids,
+		}, nil)
+	})
 }
 
 func (s *daemonService) ArchiveEmails(accountID, folder string, uids []uint32) error {
-	return s.client.Call(daemonrpc.MethodArchiveEmails, daemonrpc.ArchiveEmailsParams{
-		AccountID: accountID,
-		Folder:    folder,
-		UIDs:      uids,
-	}, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodArchiveEmails, daemonrpc.ArchiveEmailsParams{
+			AccountID: accountID,
+			Folder:    folder,
+			UIDs:      uids,
+		}, nil)
+	})
 }
 
 func (s *daemonService) MoveEmails(accountID string, uids []uint32, src, dst string) error {
-	return s.client.Call(daemonrpc.MethodMoveEmails, daemonrpc.MoveEmailsParams{
-		AccountID:    accountID,
-		UIDs:         uids,
-		SourceFolder: src,
-		DestFolder:   dst,
-	}, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodMoveEmails, daemonrpc.MoveEmailsParams{
+			AccountID:    accountID,
+			UIDs:         uids,
+			SourceFolder: src,
+			DestFolder:   dst,
+		}, nil)
+	})
 }
 
 func (s *daemonService) MarkRead(accountID, folder string, uids []uint32) error {
-	return s.client.Call(daemonrpc.MethodMarkRead, daemonrpc.MarkReadParams{
-		AccountID: accountID,
-		Folder:    folder,
-		UIDs:      uids,
-		Read:      true,
-	}, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodMarkRead, daemonrpc.MarkReadParams{
+			AccountID: accountID,
+			Folder:    folder,
+			UIDs:      uids,
+			Read:      true,
+		}, nil)
+	})
 }
 
 func (s *daemonService) MarkUnread(accountID, folder string, uids []uint32) error {
-	return s.client.Call(daemonrpc.MethodMarkRead, daemonrpc.MarkReadParams{
-		AccountID: accountID,
-		Folder:    folder,
-		UIDs:      uids,
-		Read:      false,
-	}, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodMarkRead, daemonrpc.MarkReadParams{
+			AccountID: accountID,
+			Folder:    folder,
+			UIDs:      uids,
+			Read:      false,
+		}, nil)
+	})
 }
 
 func (s *daemonService) QueueEmail(accountID string, to, cc, bcc []string, subject, body, htmlBody string, images map[string][]byte, attachments map[string][]byte, inReplyTo string, references []string, signSMIME, encryptSMIME, signPGP, encryptPGP bool, delaySeconds int, prebuiltRaw []byte) (string, error) {
 	var result daemonrpc.QueueEmailResult
-	err := s.client.Call(daemonrpc.MethodQueueEmail, daemonrpc.QueueEmailParams{
-		Email: daemonrpc.SendEmailParams{
-			AccountID:    accountID,
-			To:           to,
-			Cc:           cc,
-			Bcc:          bcc,
-			Subject:      subject,
-			Body:         body,
-			HTMLBody:     htmlBody,
-			Images:       images,
-			Attachments:  attachments,
-			InReplyTo:    inReplyTo,
-			References:   references,
-			SignSMIME:    signSMIME,
-			EncryptSMIME: encryptSMIME,
-			SignPGP:      signPGP,
-			EncryptPGP:   encryptPGP,
-			PrebuiltRaw:  prebuiltRaw,
-		},
-		DelaySeconds: delaySeconds,
-	}, &result)
+	err := s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodQueueEmail, daemonrpc.QueueEmailParams{
+			Email: daemonrpc.SendEmailParams{
+				AccountID:    accountID,
+				To:           to,
+				Cc:           cc,
+				Bcc:          bcc,
+				Subject:      subject,
+				Body:         body,
+				HTMLBody:     htmlBody,
+				Images:       images,
+				Attachments:  attachments,
+				InReplyTo:    inReplyTo,
+				References:   references,
+				SignSMIME:    signSMIME,
+				EncryptSMIME: encryptSMIME,
+				SignPGP:      signPGP,
+				EncryptPGP:   encryptPGP,
+				PrebuiltRaw:  prebuiltRaw,
+			},
+			DelaySeconds: delaySeconds,
+		}, &result)
+	})
 	return result.JobID, err
 }
 
 func (s *daemonService) CancelEmail(jobID string) error {
-	return s.client.Call(daemonrpc.MethodCancelEmail, daemonrpc.CancelEmailParams{
-		JobID: jobID,
-	}, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodCancelEmail, daemonrpc.CancelEmailParams{
+			JobID: jobID,
+		}, nil)
+	})
 }
 
 func (s *daemonService) FetchFolders(accountID string) ([]backend.Folder, error) {
 	var folders []backend.Folder
-	err := s.client.Call(daemonrpc.MethodFetchFolders, daemonrpc.FetchFoldersParams{
-		AccountID: accountID,
-	}, &folders)
+	err := s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodFetchFolders, daemonrpc.FetchFoldersParams{
+			AccountID: accountID,
+		}, &folders)
+	})
 	return folders, err
 }
 
 func (s *daemonService) RefreshFolder(accountID, folder string) error {
-	return s.client.Call(daemonrpc.MethodRefreshFolder, daemonrpc.RefreshFolderParams{
-		AccountID: accountID,
-		Folder:    folder,
-	}, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodRefreshFolder, daemonrpc.RefreshFolderParams{
+			AccountID: accountID,
+			Folder:    folder,
+		}, nil)
+	})
 }
 
 func (s *daemonService) Subscribe(accountID, folder string) error {
-	return s.client.Call(daemonrpc.MethodSubscribe, daemonrpc.SubscribeParams{
-		AccountID: accountID,
-		Folder:    folder,
-	}, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodSubscribe, daemonrpc.SubscribeParams{
+			AccountID: accountID,
+			Folder:    folder,
+		}, nil)
+	})
 }
 
 func (s *daemonService) Unsubscribe(accountID, folder string) error {
-	return s.client.Call(daemonrpc.MethodUnsubscribe, daemonrpc.UnsubscribeParams{
-		AccountID: accountID,
-		Folder:    folder,
-	}, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodUnsubscribe, daemonrpc.UnsubscribeParams{
+			AccountID: accountID,
+			Folder:    folder,
+		}, nil)
+	})
 }
 
 func (s *daemonService) ReloadConfig() error {
-	return s.client.Call(daemonrpc.MethodReloadConfig, nil, nil)
+	return s.call(func(c *Client) error {
+		return c.Call(daemonrpc.MethodReloadConfig, nil, nil)
+	})
 }
 
 func (s *daemonService) Events() <-chan *daemonrpc.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.client == nil {
+		ch := make(chan *daemonrpc.Event)
+		close(ch)
+		return ch
+	}
 	return s.client.Events()
 }
 
 func (s *daemonService) IsDaemon() bool { return true }
 
 func (s *daemonService) Close() error {
-	return s.client.Close()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
 }
 
 // directService runs operations in-process (no daemon).


### PR DESCRIPTION
## What?

Fixes 2 bugs causing connection close and daemon socket death.

1. Added a `call()`  wrapper around all `daemonService` methods that:

* Detects connection-level errors via `isConnError()`
* Closes the dead client and calls `tryConnectWithConfig()` to reconnect (auto-starts
daemon if needed)
* Retries the operation once on the fresh connection

2. Added `closeMu sync.Mutex` to serialize the `close(done)` operation between `Close()` and `readLoop()`.

## Why?

When socket died, matcha became unusable for 5-10 minutes
