### PR TITLE
fix: release fail

### DIFF
--- a/.github/workflows/bot-build.yml
+++ b/.github/workflows/bot-build.yml
@@ -134,8 +134,8 @@ jobs:
           zig cc -c -target aarch64-linux-musl -o "$RUNNER_TEMP/pcsclite_stub_arm64.o" "$RUNNER_TEMP/pcsclite_stub.c"
 
           mkdir -p "$PCSC_DIR/lib/amd64" "$PCSC_DIR/lib/arm64"
-          ar rcs "$PCSC_DIR/lib/amd64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_amd64.o"
-          ar rcs "$PCSC_DIR/lib/arm64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_arm64.o"
+          zig ar rcs "$PCSC_DIR/lib/amd64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_amd64.o"
+          zig ar rcs "$PCSC_DIR/lib/arm64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_arm64.o"
 
           cat > "$PCSC_DIR/lib/pkgconfig/libpcsclite.pc" << EOF
           Name: libpcsclite

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,8 +80,8 @@ jobs:
           zig cc -c -target aarch64-linux-musl -o "$RUNNER_TEMP/pcsclite_stub_arm64.o" "$RUNNER_TEMP/pcsclite_stub.c"
 
           mkdir -p "$PCSC_DIR/lib/amd64" "$PCSC_DIR/lib/arm64"
-          ar rcs "$PCSC_DIR/lib/amd64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_amd64.o"
-          ar rcs "$PCSC_DIR/lib/arm64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_arm64.o"
+          zig ar rcs "$PCSC_DIR/lib/amd64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_amd64.o"
+          zig ar rcs "$PCSC_DIR/lib/arm64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_arm64.o"
 
           # Create pkg-config file — Libs will be overridden per-arch via CGO_LDFLAGS in goreleaser
           cat > "$PCSC_DIR/lib/pkgconfig/libpcsclite.pc" << EOF

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -146,8 +146,8 @@ jobs:
           zig cc -c -target aarch64-linux-musl -o "$RUNNER_TEMP/pcsclite_stub_arm64.o" "$RUNNER_TEMP/pcsclite_stub.c"
 
           mkdir -p "$PCSC_DIR/lib/amd64" "$PCSC_DIR/lib/arm64"
-          ar rcs "$PCSC_DIR/lib/amd64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_amd64.o"
-          ar rcs "$PCSC_DIR/lib/arm64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_arm64.o"
+          zig ar rcs "$PCSC_DIR/lib/amd64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_amd64.o"
+          zig ar rcs "$PCSC_DIR/lib/arm64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_arm64.o"
 
           # Create pkg-config file — Libs will be overridden per-arch via CGO_LDFLAGS in goreleaser
           cat > "$PCSC_DIR/lib/pkgconfig/libpcsclite.pc" << EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,8 @@ jobs:
           zig cc -c -target aarch64-linux-musl -o "$RUNNER_TEMP/pcsclite_stub_arm64.o" "$RUNNER_TEMP/pcsclite_stub.c"
 
           mkdir -p "$PCSC_DIR/lib/amd64" "$PCSC_DIR/lib/arm64"
-          ar rcs "$PCSC_DIR/lib/amd64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_amd64.o"
-          ar rcs "$PCSC_DIR/lib/arm64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_arm64.o"
+          zig ar rcs "$PCSC_DIR/lib/amd64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_amd64.o"
+          zig ar rcs "$PCSC_DIR/lib/arm64/libpcsclite.a" "$RUNNER_TEMP/pcsclite_stub_arm64.o"
 
           # Create pkg-config file
           cat > "$PCSC_DIR/lib/pkgconfig/libpcsclite.pc" << EOF


### PR DESCRIPTION
## What?

Replaces `ar rcs` --> `zig ar rcs`

## Why?

Workflows failed previously
