### PR TITLE
feat: change layout per email view

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -878,7 +878,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 		config.Keybinds.Global.CommandPalette != "" &&
 		keyMsg.String() == config.Keybinds.Global.CommandPalette &&
 		palette.Allowed(m.current) {
-		cmd := m.palette.Open(palette.BuildCommands(m.current, m.folderInbox), m.width, m.contentHeight())
+		cmd := m.palette.Open(palette.BuildCommands(m.current, m.folderInbox, m.config), m.width, m.contentHeight())
 		return m, cmd
 	}
 
@@ -1497,6 +1497,55 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 
 	case tui.ConfigSavedMsg:
 		m.afterConfigSaved()
+		return m, nil
+
+	case tui.ToggleSplitOrientationMsg:
+		if m.config.EnableSplitPane && m.folderInbox != nil && m.folderInbox.HasSplitPreview() {
+			if m.config.GetSplitPaneOrientation() == config.SplitPaneVertical {
+				m.config.SplitPaneOrientation = config.SplitPaneHorizontal
+			} else {
+				m.config.SplitPaneOrientation = config.SplitPaneVertical
+			}
+			tui.ClearKittyGraphics()
+			m.folderInbox.SetSplitOrientation(m.config.GetSplitPaneOrientation())
+			m.current, cmd = m.current.Update(m.currentWindowSize())
+			return m, cmd
+		}
+		return m, nil
+
+	case tui.OpenFullscreenFromSplitMsg:
+		if m.folderInbox != nil && m.folderInbox.HasSplitPreview() {
+			previewPane := m.folderInbox.GetPreviewPane()
+			if previewPane == nil {
+				return m, nil
+			}
+			email := previewPane.GetEmail()
+			m.folderInbox.CloseSplitPreview()
+			mailbox := tui.MailboxInbox
+			if inbox := m.folderInbox.GetInbox(); inbox != nil {
+				mailbox = inbox.GetMailbox()
+			}
+			emailIndex := m.store.GetEmailIndex(email.UID, email.AccountID)
+			emailView := tui.NewEmailView(email, emailIndex, m.width, m.height, mailbox, m.config.DisableImages)
+			m.current = emailView
+			m.syncPluginStatus()
+			m.syncPluginKeyBindings()
+			m.updateCurrentWindowSize()
+			return m, tea.Batch(append(m.pluginFlagCmds(), m.current.Init())...)
+		}
+		return m, nil
+
+	case tui.OpenSplitFromFullscreenMsg:
+		if ev, ok := m.current.(*tui.EmailView); ok && m.config.EnableSplitPane && m.folderInbox != nil {
+			email := ev.GetEmail()
+			m.folderInbox.OpenSplitPreview(email.UID, email.AccountID, &email)
+			m.current = m.folderInbox
+			m.updateCurrentWindowSize()
+			markReadCmd := m.markEmailReadAndQueue(email.AccountID, email.UID, false)
+			return m, tea.Batch(append(m.pluginFlagCmds(), markReadCmd, func() tea.Msg {
+				return tui.UpdatePreviewMsg{UID: email.UID, AccountID: email.AccountID}
+			})...)
+		}
 		return m, nil
 
 	case tui.LanguageChangedMsg:

--- a/internal/palette/palette.go
+++ b/internal/palette/palette.go
@@ -84,9 +84,10 @@ func Allowed(current tea.Model) bool {
 }
 
 // BuildCommands assembles context-specific and global palette commands.
-func BuildCommands(current tea.Model, folderInbox *tui.FolderInbox) []tui.PaletteCommand {
+func BuildCommands(current tea.Model, folderInbox *tui.FolderInbox, cfg *config.Config) []tui.PaletteCommand {
 	kb := config.Keybinds
 	var cmds []tui.PaletteCommand
+	splitEnabled := cfg != nil && cfg.EnableSplitPane
 
 	switch v := current.(type) {
 	case *tui.Composer:
@@ -101,6 +102,11 @@ func BuildCommands(current tea.Model, folderInbox *tui.FolderInbox) []tui.Palett
 			tui.PaletteCommand{Title: "Delete email", Hint: kb.Email.Delete, Keywords: "trash remove", Action: KeyAction(kb.Email.Delete)},
 			tui.PaletteCommand{Title: "Toggle images", Hint: kb.Email.ToggleImages, Keywords: "pictures show hide", Action: KeyAction(kb.Email.ToggleImages)},
 		)
+		if !v.IsPreviewMode() && splitEnabled {
+			cmds = append(cmds,
+				tui.PaletteCommand{Title: "Change to split view", Keywords: "split pane preview side by side layout", Action: func() tea.Msg { return tui.OpenSplitFromFullscreenMsg{} }},
+			)
+		}
 		cmds = append(cmds, EmailExportCommands(v, folderInbox)...)
 	case *tui.Inbox, *tui.FolderInbox:
 		cmds = append(cmds,
@@ -115,6 +121,18 @@ func BuildCommands(current tea.Model, folderInbox *tui.FolderInbox) []tui.Palett
 			tui.PaletteCommand{Title: "Jump to folder", Keywords: "navigate switch folder go", Action: func() tea.Msg { return tui.JumpToFolderMsg{} }},
 		)
 		if fi, ok := current.(*tui.FolderInbox); ok && fi.HasSplitPreview() {
+			if fi.IsVerticalSplit() {
+				cmds = append(cmds,
+					tui.PaletteCommand{Title: "Change layout to horizontal", Keywords: "split pane orientation layout side by side", Action: func() tea.Msg { return tui.ToggleSplitOrientationMsg{} }},
+				)
+			} else {
+				cmds = append(cmds,
+					tui.PaletteCommand{Title: "Change layout to vertical", Keywords: "split pane orientation layout stacked top bottom", Action: func() tea.Msg { return tui.ToggleSplitOrientationMsg{} }},
+				)
+			}
+			cmds = append(cmds,
+				tui.PaletteCommand{Title: "Open in full screen", Keywords: "fullscreen full screen maximize expand", Action: func() tea.Msg { return tui.OpenFullscreenFromSplitMsg{} }},
+			)
 			if ev := fi.GetPreviewPane(); ev != nil {
 				cmds = append(cmds, EmailExportCommands(ev, folderInbox)...)
 			}

--- a/internal/palette/palette_test.go
+++ b/internal/palette/palette_test.go
@@ -36,7 +36,7 @@ func TestKeyActionEmptyBindingIsNil(t *testing.T) {
 // TestBuildPaletteCommandsAlwaysHasNav ensures global navigation commands are
 // present regardless of the active view, and that each has a runnable action.
 func TestBuildPaletteCommandsAlwaysHasNav(t *testing.T) {
-	cmds := BuildCommands(nil, nil)
+	cmds := BuildCommands(nil, nil, nil)
 
 	want := map[string]bool{
 		"Compose new email": false,
@@ -61,7 +61,7 @@ func TestBuildPaletteCommandsAlwaysHasNav(t *testing.T) {
 }
 
 func TestQuitCommandEmitsQuit(t *testing.T) {
-	for _, c := range BuildCommands(nil, nil) {
+	for _, c := range BuildCommands(nil, nil, nil) {
 		if c.Title != "Quit Matcha" {
 			continue
 		}

--- a/tui/email_view.go
+++ b/tui/email_view.go
@@ -220,6 +220,13 @@ func (m *EmailView) SetRowOffset(offset int) {
 	m.rowOffset = offset
 }
 
+// SetColumnOffset updates the horizontal offset used for out-of-band image
+// rendering. Call this after a layout change so images stay aligned with the
+// preview pane's new horizontal position.
+func (m *EmailView) SetColumnOffset(offset int) {
+	m.columnOffset = offset
+}
+
 func (m *EmailView) Init() tea.Cmd {
 	return nil
 }
@@ -597,6 +604,12 @@ func (m *EmailView) GetAccountID() string {
 // GetMailbox returns the mailbox kind for this email view
 func (m *EmailView) GetMailbox() MailboxKind {
 	return m.mailbox
+}
+
+// IsPreviewMode reports whether this EmailView is rendering inside the split
+// preview pane rather than full-screen.
+func (m *EmailView) IsPreviewMode() bool {
+	return m.isPreviewMode
 }
 
 // IsPatch returns true if the currently viewed email is a git patch.

--- a/tui/folder_inbox.go
+++ b/tui/folder_inbox.go
@@ -148,6 +148,28 @@ func (m *FolderInbox) isVerticalSplit() bool {
 	return m.splitOrientation == config.SplitPaneVertical
 }
 
+// IsVerticalSplit reports whether the split pane is oriented vertically.
+func (m *FolderInbox) IsVerticalSplit() bool {
+	return m.isVerticalSplit()
+}
+
+// CloseSplitPreview closes the split preview pane and returns to inbox-only.
+func (m *FolderInbox) CloseSplitPreview() {
+	m.closeSplitPreview()
+}
+
+// GetPreviewedUID returns the UID of the email currently shown in the split
+// preview pane, or 0 when no preview is open.
+func (m *FolderInbox) GetPreviewedUID() uint32 {
+	return m.previewedUID
+}
+
+// GetPreviewedAccountID returns the account ID of the email currently shown
+// in the split preview pane, or "" when no preview is open.
+func (m *FolderInbox) GetPreviewedAccountID() string {
+	return m.previewedAccountID
+}
+
 func (m *FolderInbox) GetUnreadCountsCopy() map[string]int {
 	if m.unread == nil {
 		return make(map[string]int)
@@ -398,6 +420,7 @@ func (m *FolderInbox) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocycl
 					previewMsg := tea.WindowSizeMsg{Width: paneWidth, Height: m.calculatePreviewHeight() - 1}
 					m.previewPane.Update(previewMsg)
 					m.previewPane.SetRowOffset(m.calculateInboxHeight() + 1)
+					m.previewPane.SetColumnOffset(m.effectiveSidebarWidth() + 2)
 				}
 			} else {
 				inboxWidth := m.calculateInboxWidth()
@@ -407,6 +430,8 @@ func (m *FolderInbox) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocycl
 				if m.previewPane != nil {
 					previewMsg := tea.WindowSizeMsg{Width: previewWidth - 2, Height: avail - 2}
 					m.previewPane.Update(previewMsg)
+					m.previewPane.SetRowOffset(0)
+					m.previewPane.SetColumnOffset(m.effectiveSidebarWidth() + 2 + inboxWidth + 2)
 				}
 			}
 		} else {

--- a/tui/messages.go
+++ b/tui/messages.go
@@ -178,6 +178,18 @@ type UpdatePreviewMsg struct {
 	AccountID string
 }
 
+// ToggleSplitOrientationMsg requests switching the split pane orientation
+// between horizontal and vertical while a split preview is open.
+type ToggleSplitOrientationMsg struct{}
+
+// OpenFullscreenFromSplitMsg requests closing the split preview and opening
+// the currently previewed email in a full-screen EmailView.
+type OpenFullscreenFromSplitMsg struct{}
+
+// OpenSplitFromFullscreenMsg requests switching from a full-screen EmailView
+// back to the split-pane layout with the same email shown in the preview.
+type OpenSplitFromFullscreenMsg struct{}
+
 type PreviewBodyFetchedMsg struct {
 	UID          uint32
 	AccountID    string


### PR DESCRIPTION
## What?

Adds options in the command palette to change vertical/horizontal layouts (if Split View is enabled) and to open in fullscreen. Works per-email.

## Why?

Some emails are easier to read in full screen, or in horizontal layout, rather than vertical.
