### PR TITLE
chore: sync gomod2nix.toml

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -2,16 +2,16 @@ schema = 3
 
 [mod]
   [mod.'charm.land/bubbles/v2']
-    version = 'v2.1.0'
-    hash = 'sha256-2OmqpBrl+taOJzAhVM6OReLmoYRxZOXx9JqFNjQjsPA='
+    version = 'v2.1.1'
+    hash = 'sha256-y0GRfSVvlxNzOX40GjcYxZdo92RjmHwU43T3ix9+IcU='
 
   [mod.'charm.land/bubbletea/v2']
-    version = 'v2.0.7'
-    hash = 'sha256-YOkvKUahFMMytHXr3AAABDifBtHt29930obiu/kx1vA='
+    version = 'v2.0.8'
+    hash = 'sha256-ZWcqUjUSKcT8uovaljKp4V8IQ7kIJtoAOGZ2VbpF3hs='
 
   [mod.'charm.land/lipgloss/v2']
-    version = 'v2.0.4'
-    hash = 'sha256-KrO8Q1/yQZBTMwysp/cAi5Kdz2/ZODBOr3C5X04zG/M='
+    version = 'v2.0.5'
+    hash = 'sha256-EZCcXcyT9XS93UcZvIF42WUXnPlPYe4YLdhdFwCZ5NI='
 
   [mod.'cunicu.li/go-iso7816']
     version = 'v0.8.8'
@@ -66,8 +66,8 @@ schema = 3
     hash = 'sha256-RHsRT2EZ1nDOElxAK+6/DC9XAaGVjDTgPvRh3pyCfY4='
 
   [mod.'github.com/charmbracelet/ultraviolet']
-    version = 'v0.0.0-20260525132238-948f4557a654'
-    hash = 'sha256-V0e1U50upnr+gWvao41MTiLHAbd5wAlt4GD8hiAVZ38='
+    version = 'v0.0.0-20260703014108-f5a850f9c2b7'
+    hash = 'sha256-cWqmxeaaHGrESdwZVtCv8mDw1Ta4xFpXidWDeIZfuHA='
 
   [mod.'github.com/charmbracelet/x/ansi']
     version = 'v0.11.7'
@@ -202,8 +202,8 @@ schema = 3
     hash = 'sha256-JlWckeGaWG+bXK8l8WEdZqmSiTwCA8b1qbmBKa/Fj3E='
 
   [mod.'github.com/mattn/go-runewidth']
-    version = 'v0.0.23'
-    hash = 'sha256-SmChZ2U1aR8pW3LPhdM7KcVF5TO6VcHgRzBtUXbBWJA='
+    version = 'v0.0.24'
+    hash = 'sha256-t2uvZkmlTXQCj76p4poI9y82iziJX2lF44UhkLgLN40='
 
   [mod.'github.com/microcosm-cc/bluemonday']
     version = 'v1.0.27'
@@ -226,8 +226,8 @@ schema = 3
     hash = 'sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo='
 
   [mod.'github.com/sahilm/fuzzy']
-    version = 'v0.1.1'
-    hash = 'sha256-f2VsDI6G+V2w31tSDzbZPi9EI2E7jRV6Aq8yeOorSZY='
+    version = 'v0.1.3'
+    hash = 'sha256-iIUiVfjmgB927jbdLrtrQrrXKcOfhvMHnC+65UZAyNY='
 
   [mod.'github.com/wagslane/go-password-validator']
     version = 'v0.3.0'


### PR DESCRIPTION
## What?

Regenerates `gomod2nix.toml` to reflect the current `go.mod` / `go.sum`.

## Why?

Keeps the Nix build in sync with Go module changes. Without this, `nix build` fails when new or upgraded Go deps are missing from `gomod2nix.toml`. Generated automatically by the gomod2nix sync workflow.