### PR TITLE
fix(daemonclient): register IMAP/POP3

### DIFF
--- a/daemonclient/service.go
+++ b/daemonclient/service.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/floatpane/matcha/backend"
+	_ "github.com/floatpane/matcha/backend/imap"    // register imap backend for directService
 	_ "github.com/floatpane/matcha/backend/jmap"    // register jmap backend for directService
 	_ "github.com/floatpane/matcha/backend/maildir" // register maildir backend for directService
+	_ "github.com/floatpane/matcha/backend/pop3"    // register pop3 backend for directService
 	"github.com/floatpane/matcha/config"
 	"github.com/floatpane/matcha/daemonrpc"
 	"github.com/floatpane/matcha/fetcher"


### PR DESCRIPTION
## What?

Register IMAP and POP3 backends in daemonclient's directService path.

## Why?

daemonclient already imports JMAP and Maildir for directService backend registration. IMAP and POP3 are supported by the app as well, but are not registered locally in daemonclient.

This keeps the direct fallback backend set consistent with the supported protocols.