### PR TITLE
fix(fetcher): decode address names

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -134,7 +134,7 @@ type Folder struct {
 func formatAddress(addr imap.Address) string {
 	email := addr.Addr()
 	if addr.Name != "" {
-		return addr.Name + " <" + email + ">"
+		return decodeHeader(addr.Name) + " <" + email + ">"
 	}
 	return email
 }


### PR DESCRIPTION
## What?

Use the existing `decodeHeader()` helper for `imap.Address.Name` in `formatAddress()`.

## Why?

RFC 2047 encoded-word display names can currently be shown raw in address headers, for example:

```text
=?UTF-8?B?RXhhbXBsZSBTZW5kZXI=?= <sender@example.com>
```

instead of:

```
Example Sender <sender@example.com>
```