### PR TITLE
fix(config): better config parse errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -663,7 +663,7 @@ func LoadConfig() (*Config, error) {
 			}
 			return &config, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("could not parse config file %s: %w", path, err)
 	}
 
 	config.DisableImages = raw.DisableImages

--- a/config/keybinds.go
+++ b/config/keybinds.go
@@ -3,6 +3,7 @@ package config
 import (
 	_ "embed"
 	"encoding/json"
+	"log"
 
 	keybind "github.com/floatpane/go-keybind"
 )
@@ -87,7 +88,9 @@ type DraftsKeys struct {
 func defaultKeybinds() KeybindsConfig {
 	var kb KeybindsConfig
 	if err := json.Unmarshal(defaultKeybindsJSON, &kb); err != nil {
-		panic("matcha: malformed default_keybinds.json: " + err.Error())
+		// This should never happen — the embedded JSON is compiled into the
+		// binary. If it does, return empty keybinds rather than panicking.
+		log.Printf("matcha: malformed default_keybinds.json (using empty keybinds): %v", err)
 	}
 	return kb
 }


### PR DESCRIPTION
## What?

Wrap config file parse errors with the file path, and replace the `panic()` in `defaultKeybinds()` with a logged warning.

## Why?

Closes #1520

When a config file is malformed, the error only showed a raw JSON parse error with no indication of which file was broken. Users had no way to know what to fix.

If the embedded `default_keybinds.json` was somehow corrupted, the application crashed with a panic instead of degrading gracefully.
