### PR TITLE
fix(sender): add SMTP dial timeouts

### DIFF
--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -22,6 +22,9 @@ const (
 	InstallTimeout = 30 * time.Second
 	// UpdateCheckTimeout bounds version checks and asset downloads from main (main.go).
 	UpdateCheckTimeout = 30 * time.Second
+	// SMTPDialTimeout bounds SMTP TCP + TLS handshake and plain TCP dial
+	// used by sender/sender.go.
+	SMTPDialTimeout = 30 * time.Second
 	// IMAPBatchActionTimeout bounds bulk IMAP operations (delete/archive/move) from main (main.go).
 	IMAPBatchActionTimeout = 60 * time.Second
 	// IMAPSearchTimeout bounds server-side IMAP search queries from main (main.go).

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -2,6 +2,7 @@ package sender
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
@@ -13,6 +14,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"mime/quotedprintable"
+	"net"
 	"net/mail"
 	"net/smtp"
 	"net/textproto"
@@ -26,6 +28,7 @@ import (
 	"github.com/emersion/go-pgpmail"
 	"github.com/floatpane/matcha/clib"
 	"github.com/floatpane/matcha/config"
+	"github.com/floatpane/matcha/internal/httpclient"
 	"github.com/floatpane/matcha/internal/loglevel"
 	"github.com/floatpane/matcha/pgp"
 	"github.com/yuin/goldmark"
@@ -682,7 +685,7 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 	allRecipients = append(allRecipients, cc...)
 	allRecipients = append(allRecipients, bcc...)
 
-	addr := fmt.Sprintf("%s:%d", smtpServer, smtpPort)
+	addr := net.JoinHostPort(smtpServer, fmt.Sprintf("%d", smtpPort))
 
 	tlsConfig := &tls.Config{
 		ServerName:         smtpServer,
@@ -700,7 +703,11 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 	// Port 465 uses implicit TLS (the connection starts with TLS).
 	// All other ports use plain TCP with optional STARTTLS upgrade.
 	if smtpPort == 465 {
-		conn, err := tls.Dial("tcp", addr, tlsConfig) //nolint:noctx
+		dialer := tls.Dialer{
+			NetDialer: &net.Dialer{Timeout: httpclient.SMTPDialTimeout},
+			Config:    tlsConfig,
+		}
+		conn, err := dialer.DialContext(context.Background(), "tcp", addr)
 		if err != nil {
 			return nil, err
 		}
@@ -711,8 +718,14 @@ func SendEmail(account *config.Account, to, cc, bcc []string, subject, plainBody
 		}
 	} else {
 		var err error
-		c, err = smtp.Dial(addr)
+		nd := &net.Dialer{Timeout: httpclient.SMTPDialTimeout}
+		conn, dialErr := nd.DialContext(context.Background(), "tcp", addr)
+		if dialErr != nil {
+			return nil, dialErr
+		}
+		c, err = smtp.NewClient(conn, smtpServer)
 		if err != nil {
+			conn.Close() //nolint:errcheck,gosec
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## What?

Add 30-second connection timeouts to both SMTP dial paths (implicit TLS on port 465 and plain TCP for other ports).

## Why?

Both `tls.Dial` and `smtp.Dial` blocked indefinitely if the remote server was slow to respond, a firewall silently dropped packets, or DNS resolution stalled. This hung the entire application with no way to cancel.

Also fixed IPv6 address formatting (`fmt.Sprintf` → `net.JoinHostPort`).
