### PR TITLE
fix: fetch attachments from the folder the email was opened in

### DIFF
--- a/main.go
+++ b/main.go
@@ -2337,6 +2337,13 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 				break
 			}
 		}
+		// Resolve the actual folder name the same way the body fetch does,
+		// so attachments in custom folders (Starred, All Mail, ...) are
+		// fetched from the folder the email was opened in, not INBOX.
+		folderName := folderInbox
+		if m.folderInbox != nil {
+			folderName = m.folderInbox.GetCurrentFolder()
+		}
 		newMsg := tui.DownloadAttachmentMsg{
 			Index:     msg.Index,
 			Filename:  msg.Filename,
@@ -2345,6 +2352,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 			AccountID: msg.AccountID,
 			Encoding:  encoding,
 			Mailbox:   msg.Mailbox,
+			Folder:    folderName,
 		}
 		return m, tea.Batch(m.current.Init(), downloadAttachmentCmd(account, email.UID, newMsg))
 
@@ -3616,7 +3624,13 @@ func downloadAttachmentCmd(account *config.Account, uid uint32, msg tui.Download
 		case tui.MailboxArchive:
 			data, err = fetcher.FetchArchiveAttachment(account, uid, msg.PartID, msg.Encoding)
 		case tui.MailboxInbox:
-			data, err = fetcher.FetchAttachment(account, uid, msg.PartID, msg.Encoding)
+			// Use the folder the email was opened in; custom folders
+			// (Starred, All Mail, ...) share the inbox mailbox kind.
+			folder := msg.Folder
+			if folder == "" {
+				folder = folderInbox
+			}
+			data, err = fetcher.FetchAttachmentFromMailbox(account, folder, uid, msg.PartID, msg.Encoding)
 		}
 
 		if err != nil {

--- a/tui/messages.go
+++ b/tui/messages.go
@@ -256,6 +256,7 @@ type DownloadAttachmentMsg struct {
 	AccountID string
 	Encoding  string
 	Mailbox   MailboxKind
+	Folder    string // actual mailbox folder name, used when Mailbox is MailboxInbox
 }
 
 type AttachmentDownloadedMsg struct {


### PR DESCRIPTION
## Summary

Attachment downloads from any folder other than INBOX (Starred, All Mail, Important, custom labels) failed with `could not fetch attachment`. The download path switched only on `MailboxKind`, and every folder-view email shares the `MailboxInbox` kind, so `downloadAttachmentCmd` always called `fetcher.FetchAttachment`, which hardcodes `INBOX`. The UID belongs to the folder the email was opened in, so the fetch either matched nothing or the wrong message.

## Fix

- Add a `Folder` field to `tui.DownloadAttachmentMsg` carrying the actual folder name.
- Resolve it in the `DownloadAttachmentMsg` handler the same way the body fetch already does (`m.folderInbox.GetCurrentFolder()`), so the attachment is fetched from the same mailbox the body came from.
- `downloadAttachmentCmd` now calls `FetchAttachmentFromMailbox` with that folder for the inbox mailbox kind, falling back to `INBOX` when unset. Sent/Trash/Archive paths are unchanged.

Fixes #1689

## Testing

- `go build ./...` and full `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)