### PR TITLE
fix: cache inline image payloads

### DIFF
--- a/config/cache.go
+++ b/config/cache.go
@@ -615,7 +615,8 @@ func removeAccountFromDraftsCache(accountID string) error {
 
 // --- Email Body Cache ---
 
-// CachedAttachment stores attachment metadata (not the binary data).
+// CachedAttachment stores attachment metadata and, for inline attachments,
+// the decoded payload needed to render CID images.
 type CachedAttachment struct {
 	Filename         string `json:"filename"`
 	PartID           string `json:"part_id"`
@@ -628,6 +629,7 @@ type CachedAttachment struct {
 	IsSMIMEEncrypted bool   `json:"is_smime_encrypted,omitempty"`
 	IsCalendarInvite bool   `json:"is_calendar_invite,omitempty"`
 	CalendarData     []byte `json:"calendar_data,omitempty"` // Raw .ics data for calendar invites
+	Data             []byte `json:"data,omitempty"`          // Decoded payload for inline attachments (e.g. CID images)
 }
 
 // CachedEmailBody stores the body and attachment metadata for a single email.
@@ -719,6 +721,7 @@ func calculateEmailBodySize(body *CachedEmailBody) int {
 		size += len(att.MIMEType)
 		size += len(att.ContentID)
 		size += len(att.CalendarData)
+		size += len(att.Data)
 	}
 	return size
 }

--- a/config/cache_test.go
+++ b/config/cache_test.go
@@ -462,6 +462,73 @@ func TestEmailBodyCache_AttachmentsPreserved(t *testing.T) {
 	}
 }
 
+func TestEmailBodyCache_InlineImageDataPreserved(t *testing.T) {
+	setup(t)
+
+	inlineData := []byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x01, 0x02, 0x03}
+	a1 := CachedAttachment{
+		Filename:  "logo.png",
+		PartID:    "2",
+		MIMEType:  "image/png",
+		ContentID: "logo@example.com",
+		Inline:    true,
+		Data:      inlineData,
+	}
+
+	a2 := CachedAttachment{
+		Filename: "report.pdf",
+		PartID:   "3",
+		MIMEType: "application/pdf",
+	}
+
+	body := CachedEmailBody{
+		UID:         1,
+		AccountID:   "account",
+		Body:        "inline image body",
+		Attachments: []CachedAttachment{a1, a2},
+	}
+
+	threshold := 100 * 1024 * 1024
+
+	if err := SaveEmailBody("INBOX", body, threshold); err != nil {
+		t.Fatalf("SaveEmailBody: %v", err)
+	}
+
+	output := GetCachedEmailBody("INBOX", 1, "account", threshold)
+	if output == nil {
+		t.Fatal("GetCachedEmailBody returned nil")
+	}
+
+	if len(output.Attachments) != 2 {
+		t.Fatalf("expected 2 attachments, got %d", len(output.Attachments))
+	}
+
+	if got := output.Attachments[0].Data; !slices.Equal(got, inlineData) {
+		t.Errorf("inline attachment Data: got %v, want %v", got, inlineData)
+	}
+
+	if output.Attachments[1].Data != nil {
+		t.Errorf("non-inline attachment should not carry Data, got %v", output.Attachments[1].Data)
+	}
+}
+
+func TestEmailBodyCache_InlineImageDataCountsTowardSize(t *testing.T) {
+	body := CachedEmailBody{
+		UID:       1,
+		AccountID: "account",
+		Body:      "hello",
+		Attachments: []CachedAttachment{
+			{Data: []byte("0123456789")},
+			{Data: []byte("ABCDE")},
+		},
+	}
+
+	got := calculateEmailBodySize(&body)
+	if got != len(body.Body)+10+5 {
+		t.Errorf("calculateEmailBodySize: got %d, want %d", got, len(body.Body)+10+5)
+	}
+}
+
 func TestLRU_EvictsLeastRecentlyUsed(t *testing.T) {
 	setup(t)
 

--- a/main.go
+++ b/main.go
@@ -960,6 +960,9 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 				if ca.IsCalendarInvite && len(ca.CalendarData) > 0 {
 					att.Data = ca.CalendarData
 				}
+				if ca.Inline && len(ca.Data) > 0 {
+					att.Data = ca.Data
+				}
 				attachments = append(attachments, att)
 			}
 			return m, func() tea.Msg {
@@ -980,14 +983,18 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 			folderName := m.folderInbox.GetCurrentFolder()
 			var cachedAttachments []config.CachedAttachment
 			for _, a := range msg.Attachments {
-				cachedAttachments = append(cachedAttachments, config.CachedAttachment{
+				ca := config.CachedAttachment{
 					Filename:  a.Filename,
 					PartID:    a.PartID,
 					Encoding:  a.Encoding,
 					MIMEType:  a.MIMEType,
 					ContentID: a.ContentID,
 					Inline:    a.Inline,
-				})
+				}
+				if a.Inline && len(a.Data) > 0 {
+					ca.Data = a.Data
+				}
+				cachedAttachments = append(cachedAttachments, ca)
 			}
 			go func() {
 				err := config.SaveEmailBody(folderName, config.CachedEmailBody{
@@ -1506,6 +1513,9 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 				if ca.IsCalendarInvite && len(ca.CalendarData) > 0 {
 					att.Data = ca.CalendarData
 				}
+				if ca.Inline && len(ca.Data) > 0 {
+					att.Data = ca.Data
+				}
 				attachments = append(attachments, att)
 			}
 			return m, func() tea.Msg {
@@ -1555,6 +1565,9 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:gocyclo
 			}
 			if a.IsCalendarInvite && len(a.Data) > 0 {
 				ca.CalendarData = a.Data
+			}
+			if a.Inline && len(a.Data) > 0 {
+				ca.Data = a.Data
 			}
 			cachedAttachments = append(cachedAttachments, ca)
 		}


### PR DESCRIPTION
## What?

Inline `cid:` images never render. `CachedAttachment` stored only attachment metadata, so the decoded payload of inline attachments was dropped on cache write and never restored on cache read. `inlineImagesFromAttachments` skips attachments with empty `Data`, so the CID lookup always resolved against an empty map.

This PR adds a `Data []byte` field to `CachedAttachment` and:
- persists the decoded payload for inline attachments in both cache-write paths (`PreviewBodyFetchedMsg`, `EmailBodyFetchedMsg`),
- restores it in both cache-read paths,
- counts it in `calculateEmailBodySize` so LRU accounting stays accurate.

## Why?

Fixes #1702. With the payload cached, the CID lookup in `ProcessBodyWithInline` resolves and inline images render via the Kitty graphics protocol like remote ones.