### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Matcha Documention is available on [our website](https://docs.matcha.email)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=floatpane/matcha&type=date&legend=top-left)](https://www.star-history.com/#floatpane/matcha&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=floatpane/matcha&type=date&legend=top-left)](https://star-history.dera.page/#floatpane/matcha&type=date&legend=top-left)
 
 ## Contributing
 


### PR DESCRIPTION
## Why?

The star history chart in the README is currently broken.

## What?

This change points it to an alternative chart source so it renders correctly again.